### PR TITLE
Add service-function implementation

### DIFF
--- a/src/juxt/site/alpha/function.clj
+++ b/src/juxt/site/alpha/function.clj
@@ -1,0 +1,4 @@
+(ns juxt.site.alpha.function
+  (:require [juxt.site.alpha :as site]))
+
+(defmulti invoke-service-function ::site/service-function)


### PR DESCRIPTION
Currently passes a context map to a multi-method, considering registering into
mutable state as an alternative.