### PR TITLE
Small changes for rules

### DIFF
--- a/bin/site
+++ b/bin/site
@@ -23,6 +23,11 @@
 
 (def site-root-dir (io/file (first *command-line-args*)))
 
+(defn edn-to-json
+  [edn]
+  (-> (edn/read-string {:readers {'juxt.site.alpha/as-str pr-str}} edn)
+      (json/encode)))
+
 (defn error! [& msg]
   (apply println (apply str ansi/red-font "fail:" ansi/reset-font) msg))
 
@@ -435,9 +440,9 @@
            (format "%s/_site/rules/%s" base-uri name)
            {:headers {"authorization" (format "Bearer %s" access-token)
                       "content-type" "application/json"}
-            :body (str/replace
-                   (slurp (io/file rule))
-                   "{{base-uri}}" base-uri)
+            :body (cond-> (slurp (io/file rule))
+                    :always (str/replace "{{base-uri}}" base-uri)
+                    (re-matches #".*\.edn$" rule) edn-to-json)
             :throw false})]
       (cond
         (= status 201)
@@ -472,8 +477,7 @@
             :body (cond-> (slurp (io/file trigger))
                     base-uri (str/replace "{{base-uri}}" base-uri)
                     (re-matches #".*\.edn$" trigger)
-                    ((fn [x] (-> (edn/read-string {:readers {'juxt.site.alpha/as-str pr-str}} x)
-                                 (json/encode)))))
+                    edn-to-json)
             :throw false})]
       (cond
         (= status 201)

--- a/src/juxt/site/alpha/openapi.edn
+++ b/src/juxt/site/alpha/openapi.edn
@@ -562,12 +562,14 @@
       {"description" "juxt.pass.alpha/description"
        "target" "juxt.pass.alpha/target"
        "effect" "juxt.pass.alpha/effect"
+       "limiting-clauses" "juxt.pass.alpha/limiting-clauses"
        "maxContentLength" "juxt.http.alpha/max-content-length"}
       :properties
       {"type" {:const "Rule"}
        "description" {:type "string"}
        "target" {:type "string" :juxt.jinx.alpha/as "edn"}
        "effect" {:type "string" :juxt.jinx.alpha/as "keyword"}
+       "limiting-clauses" {:type "string" :juxt.jinx.alpha/as "edn"}
        "maxContentLength" {:type "integer"}}}]}
 
    "IdentifiedRule"


### PR DESCRIPTION
 - Use `as-str` for rules also in `bin/site`
 - Unnest eql/pull queries implicitly
 - Convert limiting-clauses in site api