### PR TITLE
Add reader for regexes

### DIFF
--- a/src/juxt/site/alpha/resources.clj
+++ b/src/juxt/site/alpha/resources.clj
@@ -13,7 +13,9 @@
 
 (defn read-forms [r]
   (lazy-seq
-   (let [res (edn/read {:eof :eof} r)]
+   (let [res (edn/read {:eof :eof
+                        :readers {'regex #(re-pattern %)}}
+                       r)]
      (when-not (= res :eof)
        (cons res (read-forms r))))))
 


### PR DESCRIPTION
This allows us to post resources with a regex string, we use #regex as the #"..." syntax is not a part of edn.

(Edn Regex Issue covered in more detail here https://groups.google.com/g/clojure/c/htOjm8tu3-o/m/Y7spvfXtAQAJ)