### PR TITLE
Add separation between sns/ses sending

### DIFF
--- a/src/juxt/mail/alpha/mail.clj
+++ b/src/juxt/mail/alpha/mail.clj
@@ -4,7 +4,7 @@
   (:require
    [amazonica.aws.simpleemail :as ses]
    [amazonica.aws.sns :as sns]
-   ;;   [amazonica.aws.pinpoint :as pp]
+   [integrant.core :as ig]
    [juxt.site.alpha.triggers :as triggers]
    [crux.api :as x]
    [clojure.tools.logging :as log]
@@ -16,22 +16,45 @@
 (alias 'site (create-ns 'juxt.site.alpha))
 (alias 'mail (create-ns 'juxt.mail.alpha))
 
-(defn send-sms! [from-sms-name to-phone-number subject text-body]
-  (sns/publish :message (str subject "\n--\n" text-body)
-               :phone-number to-phone-number
-               :message-attributes {"AWS.SNS.SMS.SenderID" (or from-sms-name "TESTSMS")
-                                    "AWS.SNS.SMS.SMSType" "Transactional"}))
+(defmethod ig/init-key ::sns-client [_ {:keys [enabled?]}]
+  (if enabled?
+    sns/publish
+    (fn [& args]
+      (log/infof "sns-client stub: %s" args))))
 
-(defn send-mail! [from to subject html-body text-body]
+(defmethod ig/init-key ::ses-client [_ {:keys [enabled?]}]
+  (if enabled?
+    ses/send-email
+    (fn [& args]
+      (log/infof "ses-client stub: %s" args))))
+
+(defn send-sms! [sns-client from-sms-name to-phone-number subject text-body]
+
+  (log/debugf "Sending sms to %s with subject %s, body %s" to-phone-number subject text-body)
+
+  (future
+    (try
+      (sns-client :message (str subject "\n--\n" text-body)
+                  :phone-number to-phone-number
+                  :message-attributes {"AWS.SNS.SMS.SenderID" (or from-sms-name "TESTSMS")
+                                       "AWS.SNS.SMS.SMSType" "Transactional"})
+      (catch Exception e
+        (log/error e)))))
+
+(defn send-mail! [ses-client from to subject html-body text-body]
 
   (log/debugf "Sending email to %s with subject %s, body %s" to subject html-body)
 
-  (ses/send-email
-   :destination {:to-addresses [to]}
-   :source from
-   :message {:subject subject
-             :body {:html html-body
-                    :text text-body}}))
+  (future
+    (try
+      (ses-client
+       :destination {:to-addresses [to]}
+       :source from
+       :message {:subject subject
+                 :body {:html html-body
+                        :text text-body}})
+      (catch Exception e
+        (log/error e)))))
 
 (defn mail-merge [template data]
   (str/replace
@@ -46,21 +69,29 @@
       "<blank>"))))
 
 (defmethod triggers/run-action! ::mail/send-emails
-  [{::site/keys [db]} {:keys [trigger action-data]}]
-  (let [{::mail/keys [html-template text-template from from-sms-name subject]} trigger
+  [{::site/keys [db ses-client]} {:keys [trigger action-data]}]
+  (let [{::mail/keys [html-template text-template from subject]} trigger
         html-template (some-> (x/entity db html-template) ::http/content)
         text-template (some-> (x/entity db text-template) ::http/content)]
     (assert html-template)
     (assert text-template)
     (doseq [{:keys [user] :as data} action-data]
-      (when-let [phone-number (:phone-number user)]
-        (send-sms!
-         from-sms-name phone-number
-         (mail-merge subject data)
-         (mail-merge text-template data)))
-
       (send-mail!
+       ses-client
        from (:email user)
        (mail-merge subject data)
        (mail-merge html-template data)
        (mail-merge text-template data)))))
+
+(defmethod triggers/run-action! ::mail/send-sms
+  [{::site/keys [db sns-client]} {:keys [trigger action-data]}]
+  (let [{::mail/keys [text-template from-sms-name subject]} trigger
+        text-template (some-> (x/entity db text-template) ::http/content)]
+    (assert text-template)
+    (doseq [{:keys [user] :as data} action-data]
+      (when-let [phone-number (:phone-number user)]
+        (send-sms!
+         sns-client
+         from-sms-name phone-number
+         (mail-merge subject data)
+         (mail-merge text-template data))))))

--- a/src/juxt/site/alpha/handler.clj
+++ b/src/juxt/site/alpha/handler.clj
@@ -1182,7 +1182,7 @@
 
 (defn wrap-initialize-request
   "Initialize request state."
-  [h {::site/keys [crux-node base-uri uri-prefix]}]
+  [h {::site/keys [crux-node base-uri uri-prefix] :as opts}]
   (assert crux-node)
   (assert base-uri)
   (fn [{:ring.request/keys [scheme] :as req}]
@@ -1207,12 +1207,12 @@
           ;; lower-case). The path, however, needs to be normalized here.
           uri (str scheme+authority (normalize-path (:ring.request/path req)))
 
-          req (into req {::site/start-date (java.util.Date.)
-                         ::site/request-id req-id
-                         ::site/uri uri
-                         ::site/crux-node crux-node
-                         ::site/db db
-                         ::site/base-uri base-uri})]
+          req (into req (merge
+                         {::site/start-date (java.util.Date.)
+                          ::site/request-id req-id
+                          ::site/uri uri
+                          ::site/db db}
+                         (dissoc opts ::site/uri-prefix)))]
 
       ;; The Ring request map becomes the container for all state collected
       ;; along the request processing pathway.


### PR DESCRIPTION
- Use a function to log sns, ses stubs in development
- Add error logging to message dispatching
- Merge remaining options from config into request map