### PR TITLE
Avoid updating nil with a keyword in ->freezeable

### DIFF
--- a/src/juxt/site/alpha/util.clj
+++ b/src/juxt/site/alpha/util.clj
@@ -61,6 +61,9 @@
   (deep-replace
    form
    (fn [form]
-     (cond-> form
-       (not (freezable? form))
-       ((fn [_] ::site/unfreezable))))))
+     (cond
+       (nil? form) nil
+
+       (not (freezable? form)) ::site/unfreezable
+
+       :else (identity form)))))


### PR DESCRIPTION
->freezeable updates nil with ::juxt/unfreezeable due to which an
internal server error is thrown while rendering the template as keyword
is not clojure.lang.Associative