### PR TITLE
Alx/default query

### DIFF
--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -136,6 +136,10 @@
           (let [f (force (get object-value field-name))]
             (if (fn? f) (f argument-values) f))
 
+          ;; If the key is 'id', we assume it should be translated to xt/id
+          (= "id" field-name)
+          (get object-value :crux.db/id)
+
           ;; Or simply try to extract the keyword
           (contains? object-value (keyword field-name))
           (get object-value (keyword field-name))


### PR DESCRIPTION
Before we were just throwing a useless error anyway, and the majority of queries just pull all documents where the type is the name of the type in the schema, so this will clean up the schema for simple cases

Also I fixed some issues with the import-resources helper (it would error and quit if there were any invalid records, which for some reason are being created by export-resources) and also auto convert id->crux.db/id. which I think is a fair assumption, people can always @site(a: "id") if they really want id as a key.