### PR TITLE
Default entity type when not provided

### DIFF
--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -150,6 +150,7 @@
                      (generate-value
                       {:type true
                        :pathPrefix type})))
+       (nil? (:juxt.site/type entity)) (assoc :juxt.site/type type)
        (:id entity) (dissoc :id)
 
        ;; This is special argument that adds Site specific attributes


### PR DESCRIPTION
@armincerf helped me figure out why the types weren't being automatically added onto the entities anymore.
I've added them back under the condition there's not a type already defined on the entity.

If it's a design decision that they aren't there anymore feel free to close this