### PR TITLE
Fix JSON encoding when response contains a java.util.regex.Matcher

### DIFF
--- a/src/juxt/site/alpha/debug.clj
+++ b/src/juxt/site/alpha/debug.clj
@@ -12,6 +12,9 @@
 (alias 'site (create-ns 'juxt.site.alpha))
 (alias 'rfc7230 (create-ns 'juxt.reap.alpha.rfc7230))
 
+(def default-object-mapper (json/object-mapper {:encoders {java.util.regex.Matcher
+                                                           (fn [mat gen] (.writeString gen (str mat)))}}))
+
 ;; Representations of a 'request', useful for debugging
 (defn json-representation-of-request [req request-to-show]
   {::http/content-type "application/json"
@@ -21,7 +24,7 @@
    (fn [req]
      (-> (sorted-map)
          (into request-to-show)
-         json/write-value-as-string
+         (json/write-value-as-string default-object-mapper)
          (str "\r\n")
          (.getBytes)))
    ;; TODO: use Cache-Control: immutable - see


### PR DESCRIPTION
This fixes the issue I ran into earlier. If you rather fix the issue by more carefully examining where we set contents of `ex-info` feel free to close.