### PR TITLE
fix mismatched block delimiters in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ is set correctly. At the time of writing brew installs openjdk 17.02 and openssl
 $ brew install openssl
 $ echo export JAVA_HOME=/usr/local/Cellar/openjdk/17.0.2/libexec/openjdk.jdk/Contents/Home >> ~/.zshrc
 $ exec zsh -l
------
+----
 
 Check that Java can find `libcrypto`:
 ----


### PR DESCRIPTION
There is a single character typo in readme in block delimiters which inverts all of the content below.

See [readme on master](https://github.com/juxt/site#macos--1015) vs [readme on the fixed branch](https://github.com/msladecek/site/tree/fix-readme-pre-blocks#macos--1015)