### PR TITLE
Add login-form module

### DIFF
--- a/opt/login-form/install
+++ b/opt/login-form/install
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+site -s check-token || site get-token
+
+site put-template --dialect "selmer" --file login.html --type 'text/html;charset=utf-8' --path /_site/templates/login.html
+site put-rule -n site-login-form -r login-form-rule.edn
+
+site put-template --dialect "selmer" --file unauthorized.html --type 'text/html;charset=utf-8' --path /_site/templates/unauthorized.html
+site post-resources -f resources.edn

--- a/opt/login-form/login-form-rule.edn
+++ b/opt/login-form/login-form-rule.edn
@@ -1,0 +1,6 @@
+{:type "Rule"
+ :target
+ #juxt.site.alpha/as-str
+ [[request :ring.request/path "/_site/login.html"]
+  [request :ring.request/method #{:get :head :options}]]
+ :effect :juxt.pass.alpha/allow}

--- a/opt/login-form/login.html
+++ b/opt/login-form/login.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Login</title>
+  </head>
+  <body>
+    <div>
+      <form method="POST" action="/_site/login">
+        <div>
+          <div>
+            <label for="username">user</label>
+            <input name="user" type="text" name="username"/>
+          </div>
+          <div>
+            <label name="password" for="password">password</label>
+            <input type="password" name="password" />
+          </div>
+          <div>
+            <input value="Login" type="submit"/>
+          </div>
+          <input type="hidden" name="_query" value="{{ query }}" />
+        </div>
+      </form>
+      <footer>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/opt/login-form/resources.edn
+++ b/opt/login-form/resources.edn
@@ -1,0 +1,21 @@
+{:crux.db/id "{{base-uri}}/_site/errors/unauthorized"
+ :juxt.site.alpha/type "ErrorResource"
+ :ring.response/status 401
+ :juxt.http.alpha/representations
+ [{:juxt.site.alpha/type "TemplatedRepresentation"
+   :juxt.site.alpha/template "{{base-uri}}/_site/templates/unauthorized.html"
+   :juxt.site.alpha/template-model juxt.pass.alpha.authentication/unauthorized-template-model}]}
+
+{:crux.db/id "{{base-uri}}/_site/login.html"
+ :juxt.http.alpha/methods #{:get :head :options}
+ :juxt.site.alpha/type "TemplatedRepresentation"
+ :juxt.site.alpha/template "{{base-uri}}/_site/templates/login.html"
+ :juxt.site.alpha/template-model juxt.pass.alpha.authentication/login-template-model}
+
+{:crux.db/id "{{base-uri}}/_site/rules/unauthorized-html-resource",
+ :juxt.site.alpha/description "The unauthorized HTML page must be accessible by all"
+ :juxt.site.alpha/type "Rule"
+ :juxt.pass.alpha/effect :juxt.pass.alpha/allow
+ :juxt.pass.alpha/target
+ [[request :ring.request/uri "{{base-uri}}/_site/errors/unauthorized.html"]
+  [request :ring.request/method #{:get :head :options}]]}

--- a/opt/login-form/unauthorized.html
+++ b/opt/login-form/unauthorized.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Unauthorized</title>
+    <meta http-equiv="Refresh" content="0; url='/_site/login.html?redirect={{ redirect|default:""|urlescape }}'" />
+  </head>
+  <body>
+    <div>
+      <h1>Unfortunately you need to login first!</h1>
+      <footer>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/src/juxt/pass/alpha/authentication.clj
+++ b/src/juxt/pass/alpha/authentication.clj
@@ -132,7 +132,7 @@
         username (get form "user")
         [user pwhash] (lookup-user db base-uri username)
         password (get form "password")
-        redirect (some-> (get form "_redirect") url-decode)]
+        redirect (some-> form (get "_query") form-decode (get "redirect"))]
     (or
      (when (and password pwhash (password/check password pwhash))
        (let [access-token (access-token)

--- a/src/juxt/pass/alpha/authentication.clj
+++ b/src/juxt/pass/alpha/authentication.clj
@@ -277,3 +277,11 @@
            (throw
             (ex-info "Auth scheme unsupported"
                      (into req {:ring.response/status 401})))))))))
+
+(defn login-template-model [req]
+  {:query (str (:ring.request/query req))})
+
+(defn unauthorized-template-model [req]
+  {:redirect (str
+               (:ring.request/path req)
+               (when-let [query (:ring.request/query req)] (str "?" query)))})

--- a/src/juxt/site/alpha/selmer.clj
+++ b/src/juxt/site/alpha/selmer.clj
@@ -56,8 +56,9 @@
         spec-db (x/with-tx db txes)
 
         template-model (assoc
-                        (::site/template-model resource)
-                        "_site" req)
+                         (templating/process-template-model
+                           (::site/template-model selected-representation) req)
+                         "_site" req)
 
         template-model
         (postwalk

--- a/src/juxt/site/alpha/templating.clj
+++ b/src/juxt/site/alpha/templating.clj
@@ -6,3 +6,37 @@
 
 (defmulti render-template
   (fn [_ template] (::site/template-engine template)) :default :selmer)
+
+(defn process-template-model [template-model {::site/keys [db] :as req}]
+  ;; A template model can be a stored query.
+  (let [f (cond
+            ;; If a symbol, it is expected to be a resolvable internal function
+            ;; (to support basic templates built on the request and internal
+            ;; Site data).
+            (symbol? template-model)
+            (try
+              (or
+                (requiring-resolve template-model)
+                (throw
+                  (ex-info
+                    (format "Requiring resolve of %s returned nil" template-model)
+                    {:template-model template-model
+                     ::site/request-context (assoc req :ring.response/status 500)})))
+              (catch Exception e
+                (throw
+                  (ex-info
+                    (format "template-model fn '%s' not resolveable" template-model)
+                    {:template-model template-model
+                     ::site/request-context (assoc req :ring.response/status 500)}
+                    e))))
+
+            (map? template-model)
+            (fn [_] template-model)
+
+            :else
+            (throw
+              (ex-info
+                "Unsupported form of template-model"
+                {:type (type template-model)
+                 ::site/request-context (assoc req :ring.response/status 500)})))]
+    (f req)))


### PR DESCRIPTION
The key changes are:
- Added logic to allow `::site/template-model` to be a symbol so that we can define a function that accepts the request, extracts the requested URL and injects it into the template to allow the user to be redirected back once they've authenticated
- Changed `POST /_site/login` to extract the redirect URL from the `_query` value and then to also parse it to get only the `redirect` value (i.e. go to `/swagger-ui/index.html` not `redirect=/swagger-ui/index.html`)
- Added the HTML page files and XTDB entity definitions