### PR TITLE
Fix issue with authorization test exception

### DIFF
--- a/test/juxt/pass/authorization_test.clj
+++ b/test/juxt/pass/authorization_test.clj
@@ -1068,11 +1068,11 @@
 
   ;; This fails because we haven't provided the ::username
 
-  (authz/do-action
-   *xt-node*
-   {::pass/subject (:xt/id CREATE_PERSON_ACTION)}
-   (:xt/id ALICE_SUBJECT)
-   BOB)
+  (is (thrown? clojure.lang.ExceptionInfo (authz/do-action
+                *xt-node*
+                {::pass/subject (:xt/id ALICE_SUBJECT)}
+                (:xt/id CREATE_PERSON_ACTION)
+                BOB)))
 
   (is (not (xt/entity (xt/db *xt-node*) (:xt/id BOB))))
 

--- a/tests.edn
+++ b/tests.edn
@@ -5,7 +5,7 @@
  :tests [{:id :test
           :test-paths ["test"]
           :ns-patterns ["juxt.site.demo-test"
-                        ;;"juxt.pass.authorization-test"
+                        "juxt.pass.authorization-test"
                         ]}]
 
  :reporter kaocha.report/documentation}


### PR DESCRIPTION
https://github.com/juxt/site/commit/33215da98daed9c4478f43a30c20383192ad1d9d changed the behavior to throw when an action could not be found.

Also the person and action ID were the wrong way around.

Now re-enabled the tests in tests.edn because they all pass.