### PR TITLE
Fix issue with authorize-application in demo-test

### DIFF
--- a/test/juxt/demo.clj
+++ b/test/juxt/demo.clj
@@ -373,7 +373,7 @@
   (do-action
    "https://site.test/subjects/repl-default"
    "https://site.test/actions/grant-permission"
-   {:xt/id "https://site.test/permissions/mal/authorize-application"
+   {:xt/id "https://site.test/permissions/mal/issue-access-token"
     :juxt.pass.alpha/user "https://site.test/users/mal"
     :juxt.pass.alpha/action "https://site.test/actions/issue-access-token"
     :juxt.pass.alpha/purpose nil})

--- a/test/juxt/site/demo_test.clj
+++ b/test/juxt/site/demo_test.clj
@@ -68,8 +68,8 @@
   (demo/demo-create-action-get-private-resource!)
   (demo/demo-grant-permission-to-get-private-resource!)
   (demo/demo-create-immutable-private-resource!)
-  ;;(demo/demo-invoke-put-application!)
-  ;;(demo/demo-invoke-authorize-application!)
+  (demo/demo-invoke-put-application!)
+  (demo/demo-invoke-authorize-application!)
   (demo/demo-create-test-subject!)
   (demo/demo-invoke-issue-access-token!)
 


### PR DESCRIPTION
This was caused by the `authorize-application` permission being overwritten by the `issue-access-token` permission.

Updated the `:xt/id` to no longer overwrite and re-enabled the `put-application` and `authorize-application` steps in the `demo-test`