### PR TITLE
Add test coverage plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ opt/graphiql/target
 *.dylib
 .clj-kondo
 **/generated/*
+/target/

--- a/deps.edn
+++ b/deps.edn
@@ -101,6 +101,11 @@
     }
    :jvm-opts ["--add-opens" "java.base/java.util.concurrent=ALL-UNNAMED"]
    }
+  :coverage
+  {:extra-paths ["test"]
+   :extra-deps {
+                lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}
+                org.eclipse.jetty/jetty-jmx {:mvn/version "9.4.44.v20210927"}}}
 
   :prod
   {:extra-paths ["prod"]

--- a/src/juxt/apex/alpha/helpers.clj
+++ b/src/juxt/apex/alpha/helpers.clj
@@ -14,7 +14,7 @@
   (let [;; Operation can contain extra config, such as uri-templates
         operation (::apex/operation resource)
 
-        resource-state (openapi/received-body->resource-state req)
+        resource-state (openapi/validate-request-payload req)
 
         ;; TODO: This is just a hack to get a demo working - the method of
         ;; determining the identifier for the new resource needs to be more


### PR DESCRIPTION
Added `:coverage` alias to `deps.edn`. This can be specified when running kaocha along with `--plugin cloverage` to generate a coverage report.

(It is possible to generate a coverage report using the alias and cloverage directly, but this will ignore the configuration in `tests.edn`)

Added target to `.gitignore` because by default a html report is generated there.

Also fixed `helpers.clj` which did not have a renamed function applied to it. This namespace does not appear to be used and could be removed at a later point.