### PR TITLE
Ignore :_siteCreateAt when verifying mutation

### DIFF
--- a/test/juxt/site/graphql_test.clj
+++ b/test/juxt/site/graphql_test.clj
@@ -280,7 +280,8 @@ type Mutation {
         (is (= {:xt/id "https://example.org/persons/mal"
                 :juxt.site/type "Person"
                 :name "Malcolm Sparks"}
-               (xt/entity db "https://example.org/persons/mal"))))
+               (-> (xt/entity db "https://example.org/persons/mal")
+                   (dissoc :_siteCreatedAt)))))
 
       (let [body (json/read-value (:ring.response/body response))]
         (is (= {"data"


### PR DESCRIPTION
Fixes a broken test that is currently causing the CI build to fail.

```
FAIL in juxt.site.graphql-test/mutation-test (graphql_test.clj:280)
Expected:
  {:name "Malcolm Sparks", :juxt.site/type "Person", :xt/id "https://example.org/persons/mal"}
Actual:
  {:name "Malcolm Sparks",
   :juxt.site/type "Person",
   :xt/id "https://example.org/persons/mal",
   +:_siteCreatedAt "2022-05-26T13:28:50.568652Z"}
```
