### PR TITLE
Make `validation` site directive possible

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -88,8 +88,9 @@
  :aliases
  {:dev
   {:extra-paths ["dev" "test"]
-   :extra-deps {;; Convenience libraries made available during development
+   :extra-deps { ;; Convenience libraries made available during development
                 org.clojure/test.check {:mvn/version "1.1.1"}
+                nrepl/nrepl {:mvn/version "0.9.0"}
                 org.clojure/alpha.spec {:git/url "https://github.com/clojure/spec-alpha2.git"
                                         :sha "99456b1856a6fd934e2c30b17920bd790dd81775"}
                 org.eclipse.jetty/jetty-jmx {:mvn/version "9.4.44.v20210927"}}

--- a/deps.edn
+++ b/deps.edn
@@ -19,6 +19,9 @@
         ;; Jetty
         ring/ring-jetty-adapter {:mvn/version "1.9.5"}
 
+        ;; GraphQL schema validation
+        metosin/malli {:mvn/version "0.8.4"}
+
         ;; Logging
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         org.slf4j/jcl-over-slf4j {:mvn/version "1.7.36"}

--- a/src/juxt/site/alpha/debug.clj
+++ b/src/juxt/site/alpha/debug.clj
@@ -20,16 +20,14 @@
   {::http/content-type "application/json"
    ::http/etag "\"v1\""
    ::http/last-modified (:juxt.site.alpha/start-date request-to-show)
+   :ring.response/headers {"Cache-Control" "public, max-age=604800, immutable"}
    ::site/body-fn
    (fn [req]
      (-> (sorted-map)
          (into request-to-show)
          (json/write-value-as-string default-object-mapper)
          (str "\r\n")
-         (.getBytes)))
-   ;; TODO: use Cache-Control: immutable - see
-   ;; https://www.keycdn.com/blog/cache-control-immutable and others
-   })
+         (.getBytes)))})
 
 (defn html-representation-of-request [{::site/keys [db base-uri]} request-to-show]
   (let [template (str base-uri "/_site/templates/debug-request.html")]
@@ -41,7 +39,6 @@
        ::site/type "TemplatedRepresentation"
        ::site/template template
        ::site/template-model request-to-show
-
        #_#_::site/body-fn
        (fn [req]
          "<h1>Coming Soon...</h1>")

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -459,7 +459,7 @@
                                      (selmer/render validation-template)
                                      edn/read-string)
         invalid? (when (seq validation-directive)
-                   (m/validate validation-template v))]
+                   (m/validate validation-directive v))]
     (when invalid?
       (me/humanize (m/explain validation-directive v)))))
 

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -636,7 +636,9 @@
                   args (if (second query-args) query-args (first query-args))
                   results
                   (try
-                    (xt/q db q args)
+                    (if (nil? args)
+                      (xt/q db q)
+                      (xt/q db q args))
                     (catch Exception e
                       (throw (ex-info "Failure when running XTDB query"
                                       {:message (ex-message e)

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -459,7 +459,7 @@
                                      (selmer/render validation-template)
                                      edn/read-string)
         invalid? (when (seq validation-directive)
-                   (m/validate validation-directive v))]
+                   (not (m/validate validation-directive v)))]
     (when invalid?
       (me/humanize (m/explain validation-directive v)))))
 

--- a/src/juxt/site/alpha/rules.clj
+++ b/src/juxt/site/alpha/rules.clj
@@ -18,8 +18,8 @@
         (str uri (hash (select-keys request-instance [::pass/target ::pass/effect])))]
 
     (->> (x/submit-tx
-          xt-node
-          [[:xtdb.api/put (merge {:xt/id location} request-instance)]])
+           xt-node
+           [[:xtdb.api/put (merge {:xt/id location} request-instance)]])
          (x/await-tx xt-node))
 
     (-> req
@@ -28,9 +28,9 @@
 
 (defn match-targets [db rules request-context]
   (let [temp-id-map (reduce-kv
-                     ;; Preserve any existing xt/id - e.g. the resource will have one
-                     (fn [acc k v] (assoc acc k (merge {:xt/id (java.util.UUID/randomUUID)} v)))
-                     {} request-context)
+                      ;; Preserve any existing xt/id - e.g. the resource will have one
+                      (fn [acc k v] (assoc acc k (merge {:xt/id (java.util.UUID/randomUUID)} v)))
+                      {} request-context)
         ;; Speculatively put each entry of the request context into the
         ;; database. This new database is only in scope for this authorization.
         db (x/with-tx db (->> temp-id-map
@@ -63,20 +63,20 @@
 
 (defn eval-triggers [db triggers request-context]
   (let [temp-id-map (reduce-kv
-                     ;; Preserve any existing xt/id - e.g. the resource will have one
-                     (fn [acc k v] (assoc acc k (merge {:xt/id (java.util.UUID/randomUUID)} v)))
-                     {} request-context)
+                      ;; Preserve any existing xt/id - e.g. the resource will have one
+                      (fn [acc k v] (assoc acc k (merge {:xt/id (java.util.UUID/randomUUID)} v)))
+                      {} request-context)
         ;; Speculatively put each entry of the request context into the
         ;; database. This new database is only in scope for this authorization.
         db (x/with-tx db (mapv (fn [e] [:xtdb.api/put e]) (vals temp-id-map)))]
 
     (keep
-     (fn [trigger-id]
-       (let [trigger (x/entity db trigger-id)
-             q (merge (::site/query trigger)
-                      {:in (vec (keys temp-id-map))})
-             action-data (apply x/q db q (map :xt/id (vals temp-id-map)))]
-         (when (seq action-data)
-           {:trigger trigger
-            :action-data action-data})))
-     triggers)))
+      (fn [trigger-id]
+        (let [trigger (x/entity db trigger-id)
+              q (merge (::site/query trigger)
+                       {:in (vec (keys temp-id-map))})
+              action-data (apply x/q db q (map :xt/id (vals temp-id-map)))]
+          (when (seq action-data)
+            {:trigger trigger
+             :action-data action-data})))
+      triggers)))

--- a/test/juxt/site/graphql_test.clj
+++ b/test/juxt/site/graphql_test.clj
@@ -299,6 +299,87 @@ type Mutation {
 (deftest mutation-test
   (mutation))
 
+(defn mutation-with-validation-directive []
+  (let [schema "
+schema { query: Query mutation: Mutation }
+type Query { person: Person }
+type Person { id: ID @site(a: \"xt/id\") name: String }
+input PersonInput { name: String! id: ID }
+
+type Mutation {
+  addPerson(
+    person: PersonInput
+  ): Person @site(
+    validation: {
+      person: \"[:map [:id {:optional true} :any] [:name [:string {:min 1 :max 20}]]]\"
+    }
+  )
+}"
+
+        query "
+mutation { addPerson(
+  person: {id: \"https://example.org/persons/mal\" name: \"Malcolm Sparks\"}) { id name }}
+"]
+
+    (submit-and-await!
+     [[:xtdb.api/put access-all-areas]
+
+      [:xtdb.api/put
+       {:xt/id "https://example.org/graphql"
+        :doc "A GraphQL endpoint"
+        :juxt.http.alpha/methods #{:post :put :options}
+        :juxt.http.alpha/acceptable "application/graphql"
+        :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
+        :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]])
+
+    ;; Install a GraphQL schema at /graphql
+    (let [response (*handler*
+                    (-> {:ring.request/method :put
+                         :ring.request/path "/graphql"}
+                        (add-body schema "application/graphql")))]
+      (is (= 204 (:ring.response/status response))))
+
+    ;; POST a mutation to that endpoint
+    (let [response
+          (*handler*
+           (-> {:ring.request/method :post
+                :ring.request/path "/graphql"}
+               (add-body query "application/graphql")))]
+
+      (when (= (get-in response [:ring.response/status]) 500)
+        (throw (ex-info "Unexpected error" {:response response})))
+
+      (is (= 200 (:ring.response/status response)))
+
+      response
+
+      (when-not (= (get-in response [:ring.response/headers "content-type"])
+                   "application/json")
+        (throw (ex-info "Unexpected content-type"
+                        {:content-type (get-in response [:ring.response/headers "content-type"])})))
+
+      ;; Ensure mutation worked
+      (let [db (xt/db *xt-node*)]
+        (is (= {:xt/id "https://example.org/persons/mal"
+                :juxt.site/type "Person"
+                :name "Malcolm Sparks"}
+               (-> (xt/entity db "https://example.org/persons/mal")
+                   (dissoc :_siteCreatedAt)))))
+
+      (let [body (json/read-value (:ring.response/body response))]
+        (is (= {"data"
+                {"addPerson"
+                 {"id" "https://example.org/persons/mal"
+                  "name" "Malcolm Sparks"}}}
+               body))
+        ;;body
+        ))
+
+    ))
+
+(deftest mutation-with-validation-directive-test []
+  (mutation-with-validation-directive))
+
 
 #_(parser/parse "mutation { addPerson { name }}")
 


### PR DESCRIPTION
Given the following `schema.graphql`:
```
schema {
  query: Query
  mutation: Mutation
}

type Query { person: Person }

input PersonInput {
  name: String!
  id: ID
}

type Person {
  id: ID
  name: String!
}

type Mutation {
  addPerson(
    person: PersonInput
  ): Person @site(
    validation: {
      person: "[:map [:id {:optional true} :any] [:name [:string {:min {{minlen}} :max 20}]]]"
    }
  )
}
```

site would perform a validation against full-featured [`malli`](https://github.com/metosin/malli) schema. [`selmer`](https://github.com/yogthos/Selmer) templating is possible although it requires some effort to move it out to system level.