### PR TITLE
Merge generic updates from client side-site

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,28 +4,27 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
 
         ;; Project skeleton - also see src/config.edn
-        integrant/integrant {:mvn/version "0.7.0"}
+        integrant/integrant {:mvn/version "0.8.0"}
         aero/aero {:mvn/version "1.1.6"}
-        io.aviso/pretty {:mvn/version "0.1.35"}
+        io.aviso/pretty {:mvn/version "1.1.1"}
 
         ;; XT
-        com.xtdb/xtdb-core {:mvn/version "1.20.0"}
-        com.xtdb/xtdb-rocksdb {:mvn/version "1.20.0"}
-        com.xtdb/xtdb-lucene {:mvn/version "1.20.0"}
-        com.xtdb/xtdb-http-server {:mvn/version "1.20.0"}
-        com.xtdb/xtdb-jdbc {:mvn/version "1.20.0"}
-        mysql/mysql-connector-java {:mvn/version "8.0.23"}
-
+        com.xtdb/xtdb-core {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-rocksdb {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-lucene {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-http-server {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-jdbc {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-s3 {:mvn/version "1.21.0"}
 
         ;; Jetty
         ring/ring-jetty-adapter {:mvn/version "1.9.5"}
 
         ;; Logging
-        org.clojure/tools.logging {:mvn/version "1.1.0"}
-        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.30"}
-        org.slf4j/jul-to-slf4j {:mvn/version "1.7.30"}
-        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.30"}
-        ch.qos.logback/logback-classic {:mvn/version "1.2.3"
+        org.clojure/tools.logging {:mvn/version "1.2.4"}
+        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.36"}
+        org.slf4j/jul-to-slf4j {:mvn/version "1.7.36"}
+        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.36"}
+        ch.qos.logback/logback-classic {:mvn/version "1.2.11"
                                         :exclusions [org.slf4j/slf4j-api]}
 
         ;; Content negotiation
@@ -47,25 +46,25 @@
         #_{:local/root "../jinx"}
 
         ;; Ring for some utility code
-        ring/ring-core {:mvn/version "1.9.1"}
+        ring/ring-core {:mvn/version "1.9.5"}
 
         ;; Passwords
-        crypto-password/crypto-password {:mvn/version "0.2.1"}
+        crypto-password/crypto-password {:mvn/version "0.3.0"}
 
         ;; Support for Representations
         clj-yaml/clj-yaml {:mvn/version "0.4.0"}
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
-        metosin/jsonista {:mvn/version "0.2.7"}
-        json-html/json-html {:mvn/version "0.4.0"}
+        metosin/jsonista {:mvn/version "0.3.6"}
+        json-html/json-html {:mvn/version "0.4.7"}
 
         ;; Selmer templating
-        selmer/selmer {:mvn/version "1.12.40"}
+        selmer/selmer {:mvn/version "1.12.50"}
 
         ;; REPL highlighting
-        mvxcvi/puget {:mvn/version "1.3.1"}
+        mvxcvi/puget {:mvn/version "1.3.2"}
 
         ;; Time
-        tick/tick {:mvn/version "0.5.0-RC4"}
+        tick/tick {:mvn/version "0.5.0-RC6"}
 
         ;; Removing AWS means we now need a direct dependency on this jar for an
         ;; internal Nippy function. This is provided by later versions of XT, so
@@ -80,17 +79,16 @@
 
         ;; Required for OAuth2, not necessarily only for Auth0 since it
         ;; implements the relevant standards so any OAuth2 provided should work.
-        com.auth0/java-jwt {:mvn/version "3.18.3"}
-        com.auth0/jwks-rsa {:mvn/version "0.20.1"}
-        }
+        com.auth0/java-jwt {:mvn/version "3.19.2"}
+        com.auth0/jwks-rsa {:mvn/version "0.21.1"}}
 
  :aliases
  {:dev
   {:extra-paths ["dev" "test"]
-   :extra-deps { ;; Convenience libraries made available during development
-                org.clojure/test.check {:mvn/version "0.9.0"}
+   :extra-deps {;; Convenience libraries made available during development
+                org.clojure/test.check {:mvn/version "1.1.1"}
                 org.clojure/alpha.spec {:git/url "https://github.com/clojure/spec-alpha2.git"
-                                        :sha "c087ded910b3532a938b37e853df79fc3b9c48c1"}
+                                        :sha "99456b1856a6fd934e2c30b17920bd790dd81775"}
                 org.eclipse.jetty/jetty-jmx {:mvn/version "9.4.44.v20210927"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
               "-Dclojure.server.site={:port,50505,:accept,juxt.site.alpha.repl-server/repl}"
@@ -99,9 +97,9 @@
   :test
   {:extra-paths ["test"]
    :extra-deps
-   {lambdaisland/kaocha {:mvn/version "1.0.887"}
+   {lambdaisland/kaocha {:mvn/version "1.66.1034"}
     lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
-    nrepl/nrepl {:mvn/version "0.9.0-beta4"}}}
+    nrepl/nrepl {:mvn/version "0.9.0"}}}
 
   :prod
   {:extra-paths ["prod"]
@@ -111,5 +109,5 @@
               "-Dcom.sun.management.jmxremote.port=8001"
               "--illegal-access=warn"]
    ;; nREPL can be useful debugging prod
-   :extra-deps {nrepl/nrepl {:mvn/version "0.9.0-beta4"}
+   :extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
                 org.eclipse.jetty/jetty-jmx {:mvn/version "9.4.44.v20210927"}}}}}

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -16,14 +16,13 @@
    [clojure.tools.logging :as log]
    [clojure.walk :refer [postwalk keywordize-keys]]
    [clojure.edn :as edn]
-   [tick.core :as t]))
-
-(alias 'apex (create-ns 'juxt.apex.alpha))
-(alias 'site (create-ns 'juxt.site.alpha))
-(alias 'http (create-ns 'juxt.http.alpha))
-(alias 'grab (create-ns 'juxt.grab.alpha))
-(alias 'pass (create-ns 'juxt.pass.alpha))
-(alias 'g (create-ns 'juxt.grab.alpha.graphql))
+   [tick.core :as t]
+   [juxt.apex.alpha :as-alias apex]
+   [juxt.site.alpha :as-alias site]
+   [juxt.http.alpha :as-alias http]
+   [juxt.grab.alpha :as-alias grab]
+   [juxt.pass.alpha :as-alias pass]
+   [juxt.grab.alpha.graphql :as-alias g]))
 
 (defn field->type
   [field]
@@ -406,9 +405,9 @@
                 :_siteQuery (and query (pr-str query)))))
 
 (defn infer-query
-  [db xt-node subject field query args]
+  [db xt-node subject field query]
   (let [type (field->type field)
-        results (pull-entities db xt-node subject (xt/q db query type) query)]
+        results (pull-entities db xt-node subject (xt/q db query) query)]
     (or (process-xt-results field results)
         (throw (ex-info "No resolver found for " type)))))
 
@@ -610,7 +609,10 @@
                   args (if (second query-args) query-args (first query-args))
                   results
                   (try
-                    (xt/q db q args)
+                    (if (nil? args)
+                      (xt/q db q)
+                      (xt/q db q args))
+
                     (catch Exception e
                       (throw (ex-info "Failure when running XTDB query"
                                       {:message (ex-message e)
@@ -762,8 +764,7 @@
                          xt-node
                          subject
                          field
-                         (to-xt-query opts)
-                         argument-values)
+                         (to-xt-query opts))
 
             (get argument-values "id")
             (xt/entity db (get argument-values "id"))

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -65,7 +65,8 @@
              ['e :_siteCreatedAt '_siteCreatedAt]]}))
 
 (defn to-xt-query
-  [{:keys [custom-xt-query field argument-values type-k site-args object-value]}]
+  [{:keys [custom-xt-query field argument-values type-k
+           site-args object-value juxt.pass.alpha/subject]}]
   (let [values argument-values
         field-or-type (or
                         (get site-args "type")
@@ -86,6 +87,7 @@
                 (and (map? x) (:edn x))
                 (-> (get :edn)
                     (selmer/render {"type" type-k
+                                    "subject" (::pass/username subject)
                                     "object-id" (:xt/id object-value)
                                     "args" values})
                     edn/read-string)

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -27,34 +27,34 @@
 (defn field->type
   [field]
   (or
-   (-> field
-       ::g/type-ref
-       ::g/non-null-type
-       ::g/list-type
-       ::g/name)
-   (-> field
-       ::g/type-ref
-       ::g/non-null-type
-       ::g/list-type
-       ::g/non-null-type
-       ::g/name)
-   (-> field
-       ::g/type-ref
-       ::g/list-type
-       ::g/name)
-   (-> field
-       ::g/type-ref
-       ::g/name)
-   (-> field
-       ::g/type-ref
-       ::g/non-null-type
-       ::g/name)))
+    (-> field
+        ::g/type-ref
+        ::g/non-null-type
+        ::g/list-type
+        ::g/name)
+    (-> field
+        ::g/type-ref
+        ::g/non-null-type
+        ::g/list-type
+        ::g/non-null-type
+        ::g/name)
+    (-> field
+        ::g/type-ref
+        ::g/list-type
+        ::g/name)
+    (-> field
+        ::g/type-ref
+        ::g/name)
+    (-> field
+        ::g/type-ref
+        ::g/non-null-type
+        ::g/name)))
 
 (defn list-type?
   [type-ref]
   (or
-   (-> type-ref ::g/non-null-type ::g/list-type)
-   (::g/list-type type-ref)))
+    (-> type-ref ::g/non-null-type ::g/list-type)
+    (::g/list-type type-ref)))
 
 (defn default-query
   [field-or-type type-k]
@@ -68,32 +68,32 @@
   [{:keys [custom-xt-query field argument-values type-k site-args object-value]}]
   (let [values argument-values
         field-or-type (or
-                       (get site-args "type")
-                       field)
+                        (get site-args "type")
+                        field)
         query (or
-               custom-xt-query
-               (get site-args "q")
-               (default-query field-or-type type-k))
+                custom-xt-query
+                (get site-args "q")
+                (default-query field-or-type type-k))
         result
         (postwalk
-         (fn [x]
-           (try
-             (cond-> x
-               (and (map? x) (:keyword x))
-               (-> (get :keyword) keyword)
-               (and (map? x) (:set x))
-               (-> (get :set) set)
-               (and (map? x) (:edn x))
-               (-> (get :edn)
-                   (selmer/render {"type" type-k
-                                   "object-id" (:xt/id object-value)
-                                   "args" values})
-                   edn/read-string)
-               (= 'type x)
-               ((constantly type-k)))
-             (catch Exception e
-               (throw (ex-info "Error in q site arg" {:x x} e)))))
-         query)
+          (fn [x]
+            (try
+              (cond-> x
+                (and (map? x) (:keyword x))
+                (-> (get :keyword) keyword)
+                (and (map? x) (:set x))
+                (-> (get :set) set)
+                (and (map? x) (:edn x))
+                (-> (get :edn)
+                    (selmer/render {"type" type-k
+                                    "object-id" (:xt/id object-value)
+                                    "args" values})
+                    edn/read-string)
+                (= 'type x)
+                ((constantly type-k)))
+              (catch Exception e
+                (throw (ex-info "Error in q site arg" {:x x} e)))))
+          query)
         limit (get values "limit")
         offset (get values "offset")
         order (keyword (get values "order"))
@@ -116,20 +116,20 @@
                        limit :desc
                        :else nil)
         result (assoc-some
-                result
-                :find (and search? '[e v s])
-                :order-by (cond
-                            search?
-                            '[[s :desc]]
-                            order-by-dir
-                            [['_siteCreatedAt order-by-dir]]
-                            :else
-                            nil)
-                :where (and search-where-clauses
-                            (vec (concat (:where result) search-where-clauses)))
-                :limit limit
-                :offset (when (pos-int? offset)
-                          offset))]
+                 result
+                 :find (and search? '[e v s])
+                 :order-by (cond
+                             search?
+                             '[[s :desc]]
+                             order-by-dir
+                             [['_siteCreatedAt order-by-dir]]
+                             :else
+                             nil)
+                 :where (and search-where-clauses
+                             (vec (concat (:where result) search-where-clauses)))
+                 :limit limit
+                 :offset (when (pos-int? offset)
+                           offset))]
     result))
 
 (defn generate-value [{:keys [type pathPrefix template] :as gen-args} args]
@@ -157,13 +157,13 @@
                             (throw (ex-info "Couldn't infer type" {:field field})))]
     (cond-> entity
       true (assoc
-            :xt/id (or
-                    (:xt/id entity)
-                    (:id entity)
-                    (generate-value
-                     {:type "UUID"
-                      :pathPrefix type}
-                     {})))
+             :xt/id (or
+                      (:xt/id entity)
+                      (:id entity)
+                      (generate-value
+                        {:type "UUID"
+                         :pathPrefix type}
+                        {})))
       ;; this should use a clock component that keeps the same time for
       ;; everything in a single graphql transcation
       (nil? (:_siteCreatedAt entity)) (assoc :_siteCreatedAt (str (t/now)))
@@ -187,98 +187,98 @@
              (throw (ex-info "Failed to resolve transform fn" {:transform transform-sym})))
         entity
         (reduce
-         (fn [acc arg-def]
-           (let [site-args (get-in arg-def [::schema/directives-by-name "site" ::g/arguments])
-                 generator-args (get site-args "gen")
-                 transform-sym (some-> site-args (get "transform") symbol)
-                 transform (when transform-sym (requiring-resolve transform-sym))
-                 kw (get-in arg-def [::schema/directives-by-name "site" ::g/arguments "a"])
-                 arg-name (::g/name arg-def)
-                 key (keyword (or kw arg-name))
-                 type-ref (::g/type-ref arg-def)
-                 arg-type (or
-                           (get-in site-args "objectType")
-                           (::g/name type-ref)
-                           (-> type-ref ::g/non-null-type ::g/name))]
+          (fn [acc arg-def]
+            (let [site-args (get-in arg-def [::schema/directives-by-name "site" ::g/arguments])
+                  generator-args (get site-args "gen")
+                  transform-sym (some-> site-args (get "transform") symbol)
+                  transform (when transform-sym (requiring-resolve transform-sym))
+                  kw (get-in arg-def [::schema/directives-by-name "site" ::g/arguments "a"])
+                  arg-name (::g/name arg-def)
+                  key (keyword (or kw arg-name))
+                  type-ref (::g/type-ref arg-def)
+                  arg-type (or
+                             (get-in site-args "objectType")
+                             (::g/name type-ref)
+                             (-> type-ref ::g/non-null-type ::g/name))]
 
-             (when (and transform-sym (not transform))
-               (throw (ex-info "Failed to resolve transform fn" {:transform transform-sym})))
+              (when (and transform-sym (not transform))
+                (throw (ex-info "Failed to resolve transform fn" {:transform transform-sym})))
 
-             (when transform
-               (log/tracef "transform is %s" transform))
+              (when transform
+                (log/tracef "transform is %s" transform))
 
-             (cond
-               arg-type                 ; not a LIST
-               (let [value (or
-                            ;; If provided we use it
-                            (get args arg-name)
-                            ;; Else we try to generate it
-                            (generate-value generator-args args)
-                            )
-                     value
-                     (cond-> value
-                       ;; We don't want symbols in XT entities, because this leaks the
-                       ;; form-plane into the data-plane!
-                       (symbol? value) str
+              (cond
+                arg-type                 ; not a LIST
+                (let [value (or
+                              ;; If provided we use it
+                              (get args arg-name)
+                              ;; Else we try to generate it
+                              (generate-value generator-args args)
+                              )
+                      value
+                      (cond-> value
+                        ;; We don't want symbols in XT entities, because this leaks the
+                        ;; form-plane into the data-plane!
+                        (symbol? value) str
 
-                       ;; Replace base-uri in string-template, only for an ID
-                       ;; since we should be careful not to tamper with other
-                       ;; values.
-                       (and (string? value) (= arg-type "ID"))
-                       (selmer/render {"base-uri" base-uri})
+                        ;; Replace base-uri in string-template, only for an ID
+                        ;; since we should be careful not to tamper with other
+                        ;; values.
+                        (and (string? value) (= arg-type "ID"))
+                        (selmer/render {"base-uri" base-uri})
 
-                       ;; Transform value
-                       transform transform)]
+                        ;; Transform value
+                        transform transform)]
 
-                 (cond
-                   (or kw (scalar? arg-type types-by-name) (enum? arg-type types-by-name))
-                   (assoc-some acc key value)
+                  (cond
+                    (or kw (scalar? arg-type types-by-name) (enum? arg-type types-by-name))
+                    (assoc-some acc key value)
 
-                   :else
-                   (try
-                     (merge acc (keywordize-keys value))
-                     ;; TODO if we need to assoc, like if someone wants to nest
-                     ;; a map inside an entity to prevent it being indexed, then
-                     ;; that needs to happen here. probably with a directive to
-                     ;; differentiate from the default which is to merge (which
-                     ;; is needed to support input types)
-                     (catch Exception e
-                       (throw
-                        (ex-info
-                         "Cannot merge value into acc"
-                         {:acc acc
-                          :arg-type arg-type
-                          :value value}
-                         e))))))
+                    :else
+                    (try
+                      (merge acc (keywordize-keys value))
+                      ;; TODO if we need to assoc, like if someone wants to nest
+                      ;; a map inside an entity to prevent it being indexed, then
+                      ;; that needs to happen here. probably with a directive to
+                      ;; differentiate from the default which is to merge (which
+                      ;; is needed to support input types)
+                      (catch Exception e
+                        (throw
+                          (ex-info
+                            "Cannot merge value into acc"
+                            {:acc acc
+                             :arg-type arg-type
+                             :value value}
+                            e))))))
 
-               ;; Is it a list? Then put in as a vector
-               (list-type? type-ref)
-               (let [val (or (get args (name key))
-                             ;; TODO: default value?
-                             (generate-value generator-args args))
-                     ;; Change a symbol value into a string
+                ;; Is it a list? Then put in as a vector
+                (list-type? type-ref)
+                (let [val (or (get args (name key))
+                              ;; TODO: default value?
+                              (generate-value generator-args args))
+                      ;; Change a symbol value into a string
 
-                     ;; We don't want symbols in XT entities, because this leaks the
-                     ;; form-plane into the data-plane!
-                     val (cond-> val (symbol? val) str)
+                      ;; We don't want symbols in XT entities, because this leaks the
+                      ;; form-plane into the data-plane!
+                      val (cond-> val (symbol? val) str)
 
-                     list-type (field->type arg-def)]
-                 (cond
-                   (scalar? list-type types-by-name) (assoc-some acc key val)
-                   :else
-                   (throw (ex-info "Unsupported list-type" {:arg-def arg-def
-                                                            :list-type list-type}))))
+                      list-type (field->type arg-def)]
+                  (cond
+                    (scalar? list-type types-by-name) (assoc-some acc key val)
+                    :else
+                    (throw (ex-info "Unsupported list-type" {:arg-def arg-def
+                                                             :list-type list-type}))))
 
-               :else (throw (ex-info "Unsupported arg-def" {:arg-def arg-def})))))
-         {}
-         (::g/arguments-definition field))]
+                :else (throw (ex-info "Unsupported arg-def" {:arg-def arg-def})))))
+          {}
+          (::g/arguments-definition field))]
     (prepare-mutation-entity opts entity transform)))
 
 (defn args-to-entities
   [{:keys [argument-values field types-by-name] :as opts}]
   (let [args (and
-              (= 1 (count argument-values))
-              (first (vals argument-values)))]
+               (= 1 (count argument-values))
+               (first (vals argument-values)))]
     (when-not args
       (throw (ex-info "Mutations that insert multiple entities must take a single InputType as their only argument"
                       argument-values)))
@@ -308,10 +308,10 @@
 (defn await-tx
   [xt-node txes]
   (xt/await-tx
-   xt-node
-   (xt/submit-tx
     xt-node
-    txes)))
+    (xt/submit-tx
+      xt-node
+      txes)))
 
 (defn xt-delete
   [id]
@@ -371,15 +371,15 @@
     (if-let [ent-ns (::pass/namespace ent)]
       (let [rules (some-> ent-ns lookup ::pass/rules)
             acls (->>
-                  (xt/q
-                   db
-                   {:find ['(pull ?acl [*])]
-                    :where '[[?acl ::pass/type "ACL"]
-                             (check ?acl ?subject ?e)]
-                    :rules rules
-                    :in '[?subject ?e]}
-                   subject e)
-                  (map first))]
+                   (xt/q
+                     db
+                     {:find ['(pull ?acl [*])]
+                      :where '[[?acl ::pass/type "ACL"]
+                               (check ?acl ?subject ?e)]
+                      :rules rules
+                      :in '[?subject ?e]}
+                     subject e)
+                   (map first))]
         (when (seq acls)
           ;; TODO: Also use the ACL to infer when/whether to select-keys
           ;;(select-keys ent (apply concat (map :keys acls)))
@@ -415,10 +415,10 @@
   (if (seq atts)
     (let [next-object-value
           (get
-           (cond-> object-value
-             (string? object-value)
-             (protected-lookup subject db xt-node))
-           (keyword (first atts)))]
+            (cond-> object-value
+              (string? object-value)
+              (protected-lookup subject db xt-node))
+            (keyword (first atts)))]
       (traverse next-object-value
                 (rest atts)
                 subject db xt-node))
@@ -473,7 +473,7 @@
                         (-> as-of t/inst)
                         (-> as-of
                             (t/parse-date-time
-                             (t/formatter :iso-local-date-time))
+                              (t/formatter :iso-local-date-time))
                             t/inst)))
                     (catch Exception e
                       (throw (ex-info "rollback mutations need a valid asOf argument"
@@ -494,296 +494,293 @@
               :as req}]
   (let [type-k
         (or
-         (some-> schema :juxt.grab.alpha.schema/directives (get "site") ::g/arguments (get "type") keyword)
-         ;; Deprecated, please don't rely on this, but rather add a directive to
-         ;; your schema: schema @site(type: "juxt.site/type")
-         :juxt.site/type)]
+          (some-> schema :juxt.grab.alpha.schema/directives (get "site") ::g/arguments (get "type") keyword)
+          ;; Deprecated, please don't rely on this, but rather add a directive to
+          ;; your schema: schema @site(type: "juxt.site/type")
+          :juxt.site/type)]
     (execute-request
-     {:schema schema
-      :document document
-      :operation-name operation-name
-      :variable-values variable-values
-      :abstract-type-resolver
-      (fn [{:keys [object-value]}]
-        (get object-value type-k))
-      :field-resolver
-      (fn [{:keys [object-type object-value field-name argument-values]
-            :as field-resolver-args}]
+      {:schema schema
+       :document document
+       :operation-name operation-name
+       :variable-values variable-values
+       :abstract-type-resolver
+       (fn [{:keys [object-value]}]
+         (get object-value type-k))
+       :field-resolver
+       (fn [{:keys [object-type object-value field-name argument-values]
+             :as field-resolver-args}]
 
-        #_(when (= "SiteError" (get-in object-type [::g/name]))
-            (def object-value object-value)
-            )
+         #_(when (= "SiteError" (get-in object-type [::g/name]))
+             (def object-value object-value))
 
-        (let [types-by-name (::schema/types-by-name schema)
-              field (get-in object-type [::schema/fields-by-name field-name])
-              site-args (get-in field [::schema/directives-by-name "site" ::g/arguments])
-              field-kind (or
-                          (-> field ::g/type-ref ::g/name types-by-name ::g/kind)
-                          (when (-> field ::g/type-ref ::g/list-type) 'LIST)
-                          (when (-> field ::g/type-ref ::g/non-null-type) 'NON_NULL))
-              mutation? (=
-                         (get-in schema [::schema/root-operation-type-names :mutation])
-                         (::g/name object-type))
-              db (try
-                   (cond
-                       (and (not mutation?)
-                            (get argument-values "asOf"))
-                       (xt/db xt-node (-> argument-values
-                                          (get "asOf")
-                                          t/instant
-                                          t/inst))
-                       (and
+         (let [types-by-name (::schema/types-by-name schema)
+               field (get-in object-type [::schema/fields-by-name field-name])
+               site-args (get-in field [::schema/directives-by-name "site" ::g/arguments])
+               field-kind (or
+                            (-> field ::g/type-ref ::g/name types-by-name ::g/kind)
+                            (when (-> field ::g/type-ref ::g/list-type) 'LIST)
+                            (when (-> field ::g/type-ref ::g/non-null-type) 'NON_NULL))
+               mutation? (=
+                           (get-in schema [::schema/root-operation-type-names :mutation])
+                           (::g/name object-type))
+               db (try
+                    (cond
+                      (and (not mutation?)
+                           (get argument-values "asOf"))
+                      (xt/db xt-node (-> argument-values
+                                         (get "asOf")
+                                         t/instant
+                                         t/inst))
+                      (and
                         (get variable-values "historicalDb")
                         (:_siteValidTime object-value))
-                       (do
-                         (xt/db xt-node (-> object-value
-                                            :_siteValidTime
-                                            t/inst)))
-                       :else
-                       db)
-                   (catch Exception _ db))
-              object-id (:xt/id object-value)
-              ;; TODO: Protected lookup please!
-              lookup-entity (fn [id] (xt/entity db id))
-              opts
-              (merge field-resolver-args
-                     {:site-args site-args
-                      :xt-node xt-node
-                      :schema schema
-                      :field field
-                      :field-kind field-kind
-                      :types-by-name types-by-name
-                      :mutation? mutation?
-                      :base-uri base-uri
-                      :type-k type-k
-                      :lookup-entity lookup-entity
-                      ::pass/subject subject
-                      :db db})]
+                      (xt/db xt-node (-> object-value
+                                         :_siteValidTime
+                                         t/inst))
+                      :else
+                      db)
+                    (catch Exception _ db))
+               object-id (:xt/id object-value)
+               ;; TODO: Protected lookup please!
+               lookup-entity (fn [id] (xt/entity db id))
+               opts
+               (merge field-resolver-args
+                      {:site-args site-args
+                       :xt-node xt-node
+                       :schema schema
+                       :field field
+                       :field-kind field-kind
+                       :types-by-name types-by-name
+                       :mutation? mutation?
+                       :base-uri base-uri
+                       :type-k type-k
+                       :lookup-entity lookup-entity
+                       ::pass/subject subject
+                       :db db})]
 
-          (cond
-            ;; The registration of a resolver should be a privileged operation, since it
-            ;; has the potential to bypass access control.
-            (get site-args "resolver")
-            (let [resolver (requiring-resolve (symbol (get site-args "resolver")))]
-              ;; Resolvers need to do their own access control
-              (resolver opts))
+           (cond
+             ;; The registration of a resolver should be a privileged operation, since it
+             ;; has the potential to bypass access control.
+             (get site-args "resolver")
+             (let [resolver (requiring-resolve (symbol (get site-args "resolver")))]
+               ;; Resolvers need to do their own access control
+               (resolver opts))
 
-            mutation? (perform-mutation! opts)
+             mutation? (perform-mutation! opts)
 
-            (get site-args "history")
-            (if-let [id (get argument-values "id")]
-              (let [limit (get argument-values "limit" 10)
-                    offset (get argument-values "offset" 0)
-                    order (case (get site-args "history")
-                            "desc" :desc
-                            "asc" :asc
-                            :desc)
-                    process-history-item
-                    (fn [{::xt/keys [valid-time doc]}]
-                      (assoc doc :_siteValidTime (t/instant valid-time)))]
-                (with-open [history (xt/open-entity-history db id order {:with-docs? true})]
-                  (->> history
-                       (iterator-seq)
-                       (drop offset)
-                       (take limit)
-                       (map process-history-item))))
-              (throw (ex-info "History queries must have an id argument" {})))
+             (get site-args "history")
+             (if-let [id (get argument-values "id")]
+               (let [limit (get argument-values "limit" 10)
+                     offset (get argument-values "offset" 0)
+                     order (case (get site-args "history")
+                             "desc" :desc
+                             "asc" :asc
+                             :desc)
+                     process-history-item
+                     (fn [{::xt/keys [valid-time doc]}]
+                       (assoc doc :_siteValidTime (t/instant valid-time)))]
+                 (with-open [history (xt/open-entity-history db id order {:with-docs? true})]
+                   (->> history
+                        (iterator-seq)
+                        (drop offset)
+                        (take limit)
+                        (map process-history-item))))
+               (throw (ex-info "History queries must have an id argument" {})))
 
-            ;; Direct lookup - useful for query roots
-            (get site-args "e")
-            (let [e (get site-args "e")]
-              (or (protected-lookup e subject db xt-node)
-                  (protected-lookup (get argument-values e) subject db xt-node)))
+             ;; Direct lookup - useful for query roots
+             (get site-args "e")
+             (let [e (get site-args "e")]
+               (or (protected-lookup e subject db xt-node)
+                   (protected-lookup (get argument-values e) subject db xt-node)))
 
-            (get site-args "q")
-            (let [object-id (:xt/id object-value)
-                  arg-keys (fn [m] (remove #{"limit" "offset" "orderBy"} (keys m)))
-                  in (cond->> (map symbol (arg-keys argument-values))
-                       object-id (concat ['object]))
-                  q (assoc
-                     (to-xt-query opts)
-                     :in (if (second in) [in] (vec in)))
+             (get site-args "q")
+             (let [object-id (:xt/id object-value)
+                   arg-keys (fn [m] (remove #{"limit" "offset" "orderBy"} (keys m)))
+                   in (cond->> (map symbol (arg-keys argument-values))
+                        object-id (concat ['object]))
+                   q (assoc
+                       (to-xt-query opts)
+                       :in (if (second in) [in] (vec in)))
 
-                  query-args (cond->> (vals argument-values)
-                               object-id (concat [object-id]))
-                  args (if (second query-args) query-args (first query-args))
-                  results
-                  (try
-                    (if (nil? args)
-                      (xt/q db q)
-                      (xt/q db q args))
+                   query-args (cond->> (vals argument-values)
+                                object-id (concat [object-id]))
+                   args (if (second query-args) query-args (first query-args))
+                   results
+                   (try
+                     (if (nil? args)
+                       (xt/q db q)
+                       (xt/q db q args))
 
-                    (catch Exception e
-                      (throw (ex-info "Failure when running XTDB query"
-                                      {:message (ex-message e)
-                                       :query (pr-str q)
-                                       :args args}
-                                      e))))
-                  limited-results (limit-results argument-values results)
-                  result-entities (cond->>
-                                      (pull-entities db xt-node subject limited-results q)
-                                      (get site-args "a")
-                                      (map (keyword (get site-args "a")))
+                     (catch Exception e
+                       (throw (ex-info "Failure when running XTDB query"
+                                       {:message (ex-message e)
+                                        :query (pr-str q)
+                                        :args args}
+                                       e))))
+                   limited-results (limit-results argument-values results)
+                   result-entities (cond->>
+                                       (pull-entities db xt-node subject limited-results q)
+                                     (get site-args "a")
+                                     (map (keyword (get site-args "a")))
 
-                                      )]
-              ;;(log/tracef "GraphQL results is %s" (seq result-entities))
+                                     )]
+               ;;(log/tracef "GraphQL results is %s" (seq result-entities))
 
-              (process-xt-results field result-entities))
+               (process-xt-results field result-entities))
 
-            (get site-args "itemForId")
-            (let [item-key (keyword (get site-args "itemForId"))
-                  query {:find ['e '_siteCreatedAt]
-                         :where [['e type-k (field->type field)]
-                                 ['e :_siteCreatedAt '_siteCreatedAt]
-                                 ['e item-key (get argument-values "id")]]}
+             (get site-args "itemForId")
+             (let [item-key (keyword (get site-args "itemForId"))
+                   query {:find ['e '_siteCreatedAt]
+                          :where [['e type-k (field->type field)]
+                                  ['e :_siteCreatedAt '_siteCreatedAt]
+                                  ['e item-key (get argument-values "id")]]}
 
-                  query (to-xt-query (assoc opts :custom-xt-query query))
-                  results (xt/q db query)
-                  result-entities (cond->> (pull-entities db xt-node subject results query)
-                                    (get site-args "a")
-                                    (map (keyword (get site-args "a"))))]
-              (vec (process-xt-results field result-entities)))
+                   query (to-xt-query (assoc opts :custom-xt-query query))
+                   results (xt/q db query)
+                   result-entities (cond->> (pull-entities db xt-node subject results query)
+                                     (get site-args "a")
+                                     (map (keyword (get site-args "a"))))]
+               (vec (process-xt-results field result-entities)))
 
-            (get site-args "a")
-            (let [att (get site-args "a")
-                  val (if (vector? att)
-                        (traverse object-value att subject db xt-node)
-                        (get object-value (keyword att)))
-                  transform-sym (some-> site-args (get "transform") symbol)
-                  transform (when transform-sym (requiring-resolve transform-sym))
-                  ]
-              (if (= field-kind 'OBJECT)
-                (protected-lookup val subject db xt-node)
-                ;; TODO: check for lists
-                (cond-> val
-                  transform transform)))
+             (get site-args "a")
+             (let [att (get site-args "a")
+                   val (if (vector? att)
+                         (traverse object-value att subject db xt-node)
+                         (get object-value (keyword att)))
+                   transform-sym (some-> site-args (get "transform") symbol)
+                   transform (when transform-sym (requiring-resolve transform-sym))]
+               (if (= field-kind 'OBJECT)
+                 (protected-lookup val subject db xt-node)
+                 ;; TODO: check for lists
+                 (cond-> val
+                   transform transform)))
 
-            (get site-args "ref")
-            (let [list? (list-type? (::g/type-ref field))
-                  ref (get site-args "ref")
-                  e (or
-                     (and (vector? ref)
-                          (traverse object-value ref subject db xt-node))
-                     (get object-value ref)
-                     (get object-value (keyword ref)))
-                  lookup-entity #(protected-lookup % subject db xt-node)
-                  type (field->type field)]
-              (if e
-                ;; referenced key exists on current entity
-                (lookup-entity e)
-                ;; try a query for any other entity which contains
-                ;; the reference key (reverse join)
-                (let [reverse-lookup-result
-                      (xt/q db {:find ['e]
-                                :where [['e type-k type]
-                                        ['e (keyword ref) (or
-                                                           (get argument-values ref)
-                                                           object-id)]]})]
-                  (if list?
-                    (map (comp lookup-entity first) reverse-lookup-result)
-                    (lookup-entity (ffirst reverse-lookup-result))))))
+             (get site-args "ref")
+             (let [list? (list-type? (::g/type-ref field))
+                   ref (get site-args "ref")
+                   e (or
+                       (and (vector? ref)
+                            (traverse object-value ref subject db xt-node))
+                       (get object-value ref)
+                       (get object-value (keyword ref)))
+                   lookup-entity #(protected-lookup % subject db xt-node)
+                   type (field->type field)]
+               (if e
+                 ;; referenced key exists on current entity
+                 (lookup-entity e)
+                 ;; try a query for any other entity which contains
+                 ;; the reference key (reverse join)
+                 (let [reverse-lookup-result
+                       (xt/q db {:find ['e]
+                                 :where [['e type-k type]
+                                         ['e (keyword ref) (or
+                                                             (get argument-values ref)
+                                                             object-id)]]})]
+                   (if list?
+                     (map (comp lookup-entity first) reverse-lookup-result)
+                     (lookup-entity (ffirst reverse-lookup-result))))))
 
-            (get site-args "each")
-            (let [att (get site-args "each")
-                  val (if (vector? att)
-                        (traverse object-value att subject db xt-node)
-                        (get object-value (keyword att)))]
-              (if (-> field ::g/type-ref list-type?)
-                (map #(protected-lookup % subject db xt-node) val)
-                (throw (ex-info "Can only used 'each' on a LIST type" {:field-kind field-kind}))))
+             (get site-args "each")
+             (let [att (get site-args "each")
+                   val (if (vector? att)
+                         (traverse object-value att subject db xt-node)
+                         (get object-value (keyword att)))]
+               (if (-> field ::g/type-ref list-type?)
+                 (map #(protected-lookup % subject db xt-node) val)
+                 (throw (ex-info "Can only used 'each' on a LIST type" {:field-kind field-kind}))))
 
-            (get site-args "siteResolver")
-            (let [resolver
-                  (case (get site-args "siteResolver")
-                    "allQueryParams"
-                    (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-parameters)
-                    "queryParam"
-                    (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-parameter)
-                    "queryString"
-                    (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-string)
-                    "constant"
-                    (requiring-resolve 'juxt.site.alpha.graphql-resolver/constant)
-                    (throw (ex-info "No such built-in resolver" {:site-resolver (get site-args "siteResolver")})))]
-              (resolver (assoc field-resolver-args ::site/request-context req)))
+             (get site-args "siteResolver")
+             (let [resolver
+                   (case (get site-args "siteResolver")
+                     "allQueryParams"
+                     (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-parameters)
+                     "queryParam"
+                     (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-parameter)
+                     "queryString"
+                     (requiring-resolve 'juxt.site.alpha.graphql-resolver/query-string)
+                     "constant"
+                     (requiring-resolve 'juxt.site.alpha.graphql-resolver/constant)
+                     (throw (ex-info "No such built-in resolver" {:site-resolver (get site-args "siteResolver")})))]
+               (resolver (assoc field-resolver-args ::site/request-context req)))
 
-            ;; A function whose input is the result of a GraphqL 'sub' query,
-            ;; propagating the same subject and under the exact same access
-            ;; control policy. This allows the function to declare its necessary
-            ;; inputs as a query.
-            ;;
-            ;; In addition, a function's results may be memoized, with each result
-            ;; stored in XTDB which acts as a large persistent memoization
-            ;; cache. For this reason, the function must be pure. The function
-            ;; must take a single map which contains the results of the sub-query
-            ;; and any argument values (which would also be used as variable
-            ;; values in the GraphQL sub-query which computes the other input
-            ;; argument).
-            ;;
-            ;; Once this feature is working, replace it with a call to a lambda or
-            ;; similarly sandboxed execution environment.
-            (get site-args "function")
-            (throw (ex-info "Feature not yet supported" {}))
+             ;; A function whose input is the result of a GraphqL 'sub' query,
+             ;; propagating the same subject and under the exact same access
+             ;; control policy. This allows the function to declare its necessary
+             ;; inputs as a query.
+             ;;
+             ;; In addition, a function's results may be memoized, with each result
+             ;; stored in XTDB which acts as a large persistent memoization
+             ;; cache. For this reason, the function must be pure. The function
+             ;; must take a single map which contains the results of the sub-query
+             ;; and any argument values (which would also be used as variable
+             ;; values in the GraphQL sub-query which computes the other input
+             ;; argument).
+             ;;
+             ;; Once this feature is working, replace it with a call to a lambda or
+             ;; similarly sandboxed execution environment.
+             (get site-args "function")
+             (throw (ex-info "Feature not yet supported" {}))
 
-            (and (= 1 (count argument-values))
-                 (= "id" (ffirst argument-values)))
-            (lookup-entity (get argument-values "id"))
+             (and (= 1 (count argument-values))
+                  (= "id" (ffirst argument-values)))
+             (lookup-entity (get argument-values "id"))
 
-            (and (= 1 (count argument-values))
-                 (= "ids" (ffirst argument-values)))
-            (map lookup-entity (get argument-values "ids"))
+             (and (= 1 (count argument-values))
+                  (= "ids" (ffirst argument-values)))
+             (map lookup-entity (get argument-values "ids"))
 
-            ;; Another strategy is to see if the field indexes the
-            ;; object-value. This strategy allows for delays to be used to prevent
-            ;; computing field values that aren't resolved.
-            (and (map? object-value) (contains? object-value field-name))
-            (let [f (force (get object-value field-name))]
-              (if (fn? f) (f argument-values) f))
+             ;; Another strategy is to see if the field indexes the
+             ;; object-value. This strategy allows for delays to be used to prevent
+             ;; computing field values that aren't resolved.
+             (and (map? object-value) (contains? object-value field-name))
+             (let [f (force (get object-value field-name))]
+               (if (fn? f) (f argument-values) f))
 
-            ;; If the key is 'id', we assume it should be translated to xt/id
-            (= "id" field-name)
-            (get object-value :xt/id)
+             ;; If the key is 'id', we assume it should be translated to xt/id
+             (= "id" field-name)
+             (get object-value :xt/id)
 
-            ;; Or simply try to extract the keyword
-            (and (map? object-value)
-                 (or
-                  ;; schema specifies this field is on the object
-                  (get-in field [::schema/directives-by-name "onObject"])
-                  (contains? object-value (keyword field-name))))
-            (let [result (get object-value (keyword field-name))]
-                (cond
-                  (-> field ::g/type-ref list-type?)
-                  (limit-results argument-values result)
-                  ;; TODO validate enum (enum? (field->type field) types-by-name)
-                  :else
-                  result))
+             ;; Or simply try to extract the keyword
+             (and (map? object-value)
+                  (or
+                    ;; schema specifies this field is on the object
+                    (get-in field [::schema/directives-by-name "onObject"])
+                    (contains? object-value (keyword field-name))))
+             (let [result (get object-value (keyword field-name))]
+               (cond
+                 (-> field ::g/type-ref list-type?)
+                 (limit-results argument-values result)
+                 ;; TODO validate enum (enum? (field->type field) types-by-name)
+                 :else
+                 result))
 
-            (and (field->type field)
-                 (not (scalar? (field->type field) types-by-name))
-                 (not (enum? (field->type field) types-by-name)))
-            (infer-query db
-                         xt-node
-                         subject
-                         field
-                         (to-xt-query opts))
+             (and (field->type field)
+                  (not (scalar? (field->type field) types-by-name))
+                  (not (enum? (field->type field) types-by-name)))
+             (infer-query db
+                          xt-node
+                          subject
+                          field
+                          (to-xt-query opts))
 
-            (get argument-values "id")
-            (xt/entity db (get argument-values "id"))
+             (get argument-values "id")
+             (xt/entity db (get argument-values "id"))
 
-            (and (get site-args "aggregate")
-                 (get site-args "type"))
-            (case (get site-args "aggregate")
-              "count" (count
-                       (xt/q
-                        db (to-xt-query opts))))
+             (and (get site-args "aggregate")
+                  (get site-args "type"))
+             (case (get site-args "aggregate")
+               "count" (count
+                         (xt/q
+                           db (to-xt-query opts))))
 
-            (= "_siteValidTime" field-name)
-            (entity-valid-time object-value db)
+             (= "_siteValidTime" field-name)
+             (entity-valid-time object-value db)
 
-            (= "_siteCreatedAt" field-name)
-            (entity-creation-time object-value db)
+             (= "_siteCreatedAt" field-name)
+             (entity-creation-time object-value db)
 
-            :else
-            (default-for-type (::g/type-ref field)))))})))
+             :else
+             (default-for-type (::g/type-ref field)))))})))
 
 (defn common-variables
   "Return the common 'built-in' variables that are bound always bound."
@@ -802,9 +799,9 @@
         _validate-schema (and (nil? schema)
                               (let [msg (str "Schema does not exist at " uri ". Are you deploying it correctly?")]
                                 (throw (ex-info
-                                        msg
-                                        {::site/errors [msg] ;; TODO
-                                         ::site/request-context (assoc req :ring.response/status 400)}))))
+                                         msg
+                                         {::site/errors [msg] ;; TODO
+                                          ::site/request-context (assoc req :ring.response/status 400)}))))
         body (some-> req ::site/received-representation ::http/body (String.))
 
         {query "query"
@@ -814,23 +811,23 @@
           "application/json" (try (some-> body json/read-value)
                                   (catch Exception e
                                     (throw
-                                     (let [msg "Error parsing JSON body"]
-                                       (ex-info
-                                        msg
-                                        {::site/errors [msg]
-                                         ::site/request-context (assoc req :ring.response/status 400)})))))
+                                      (let [msg "Error parsing JSON body"]
+                                        (ex-info
+                                          msg
+                                          {::site/errors [msg]
+                                           ::site/request-context (assoc req :ring.response/status 400)})))))
           "application/graphql" {"query" body}
 
           (throw
-           (ex-info
-            (format "Unknown content type for GraphQL request: %s" (some-> req ::site/received-representation ::http/content-type))
-            {::site/request-context req})))
+            (ex-info
+              (format "Unknown content type for GraphQL request: %s" (some-> req ::site/received-representation ::http/content-type))
+              {::site/request-context req})))
 
         _ (when (nil? query)
             (throw
-             (ex-info
-              "Nil GraphQL query"
-              {::site/request-context req})))
+              (ex-info
+                "Nil GraphQL query"
+                {::site/request-context req})))
 
         parsed-query
         (try
@@ -838,10 +835,10 @@
           (catch Exception e
             (log/error e "Error parsing GraphQL query")
             (throw
-             (ex-info
-              "Failed to parse query"
-              {::site/request-context req}
-              e))))
+              (ex-info
+                "Failed to parse query"
+                {::site/request-context req}
+                e))))
 
         compiled-query
         (try
@@ -851,24 +848,24 @@
             (let [errors (:errors (ex-data e))]
               (log/errorf "Errors %s" (pr-str errors))
               (throw
-               (ex-info
-                "Error parsing or compiling GraphQL query"
-                (cond-> {::site/request-context (assoc req :ring.response/status 400)}
-                  (seq errors) (assoc ::grab/errors errors)))))))
+                (ex-info
+                  "Error parsing or compiling GraphQL query"
+                  (cond-> {::site/request-context (assoc req :ring.response/status 400)}
+                    (seq errors) (assoc ::grab/errors errors)))))))
 
         variables (into
-                   (common-variables req)
-                   variables)
+                    (common-variables req)
+                    variables)
 
         results
         (juxt.site.alpha.graphql/query
-         schema compiled-query operation-name variables req)]
+          schema compiled-query operation-name variables req)]
 
     (-> req
         (assoc
-         :ring.response/status 200
-         :ring.response/body
-         (json/write-value-as-string results))
+          :ring.response/status 200
+          :ring.response/body
+          (json/write-value-as-string results))
         (update :ring.response/headers assoc "content-type" "application/json"))))
 
 (defn schema-resource [resource schema-str]
@@ -877,28 +874,28 @@
 
 (defn put-schema [xt-node resource schema-str]
   (xt/await-tx
-   xt-node
-   (xt/submit-tx
     xt-node
-    [[:xtdb.api/put (schema-resource resource schema-str)]])))
+    (xt/submit-tx
+      xt-node
+      [[:xtdb.api/put (schema-resource resource schema-str)]])))
 
 (defn put-handler [{::site/keys [uri db xt-node] :as req}]
   (let [schema-str (some-> req :juxt.site.alpha/received-representation :juxt.http.alpha/body (String.))
 
         _ (when-not schema-str
             (throw
-             (ex-info
-              "No schema in request"
-              {::site/request-context {:ring.response/status 400}})))
+              (ex-info
+                "No schema in request"
+                {::site/request-context {:ring.response/status 400}})))
 
         resource (xt/entity db uri)]
 
     (when (nil? resource)
       (throw
-       (ex-info
-        "GraphQL resource not configured"
-        {:uri uri
-         ::site/request-context (assoc req :ring.response/status 400)})))
+        (ex-info
+          "GraphQL resource not configured"
+          {:uri uri
+           ::site/request-context (assoc req :ring.response/status 400)})))
 
     (try
       (put-schema xt-node resource schema-str)
@@ -907,65 +904,65 @@
         (let [errors (:errors (ex-data e))]
           (if (seq errors)
             (throw
-             (ex-info
-              "Errors in schema"
-              (cond-> {::site/request-context (assoc req :ring.response/status 400)}
-                (seq errors) (assoc ::grab/errors errors))))
+              (ex-info
+                "Errors in schema"
+                (cond-> {::site/request-context (assoc req :ring.response/status 400)}
+                  (seq errors) (assoc ::grab/errors errors))))
             (throw
-             (ex-info
-              "Failed to put schema"
-              {::site/request-context (assoc req :ring.response/status 500)}
-              e))))))))
+              (ex-info
+                "Failed to put schema"
+                {::site/request-context (assoc req :ring.response/status 500)}
+                e))))))))
 
 (defn plain-text-error-message [error]
   (let [line (some-> error :location :line inc)]
     (str
-     (when line (format "%4d: " line))
-     (:message error)
-     " [" (->> (dissoc error :message)
-               sort
-               (map (fn [[k v]] (format "%s=%s" (name k) v)))
-               (str/join ", ")) "]")))
+      (when line (format "%4d: " line))
+      (:message error)
+      " [" (->> (dissoc error :message)
+                sort
+                (map (fn [[k v]] (format "%s=%s" (name k) v)))
+                (str/join ", ")) "]")))
 
 (defn put-error-text-body [req]
   (cond
     (::site/errors req)
     (->>
-     (for [error (::site/errors req)]
-       (cond-> (str \tab (plain-text-error-message error))
-         ;;(:location error) (str " (line " (-> error :location :line) ")")
-         ))
-     (into ["Schema compilation errors"])
-     (str/join (System/lineSeparator)))
+      (for [error (::site/errors req)]
+        (cond-> (str \tab (plain-text-error-message error))
+          ;;(:location error) (str " (line " (-> error :location :line) ")")
+          ))
+      (into ["Schema compilation errors"])
+      (str/join (System/lineSeparator)))
     (:ring.response/body req) (:ring.response/body req)
     :else "Unknown error, check stack trace"))
 
 (defn put-error-json-body [req]
   (json/write-value-as-string
-   {:message "Schema compilation errors"
-    :errors (::site/errors req)}))
+    {:message "Schema compilation errors"
+     :errors (::site/errors req)}))
 
 (defn post-error-text-body [req]
   (->>
-   (for [error (::site/errors req)]
-     (cond-> (str \tab (:error error))
-       (:location error) (str " (line " (-> error :location :row inc) ")")))
-   (into ["Query errors"])
-   (str/join (System/lineSeparator))))
+    (for [error (::site/errors req)]
+      (cond-> (str \tab (:error error))
+        (:location error) (str " (line " (-> error :location :row inc) ")")))
+    (into ["Query errors"])
+    (str/join (System/lineSeparator))))
 
 (defn post-error-json-body [req]
   (json/write-value-as-string
-   {:errors
-    (for [error (::site/errors req)
-          :let [location (:location error)]]
-      (cond-> error
-        location (assoc :location location)))}))
+    {:errors
+     (for [error (::site/errors req)
+           :let [location (:location error)]]
+       (cond-> error
+         location (assoc :location location)))}))
 
 (defn stored-document-resource-map [document-str schema]
   (try
     (let [document (document/compile-document
-                    (parser/parse document-str)
-                    schema)]
+                     (parser/parse document-str)
+                     schema)]
 
       {::site/graphql-compiled-query document
        ::http/body (.getBytes document-str)
@@ -975,75 +972,75 @@
       (let [errors (:errors (ex-data e))]
         (if (seq errors)
           (throw
-           (ex-info
-            "Errors in GraphQL document"
-            {::grab/errors errors}))
+            (ex-info
+              "Errors in GraphQL document"
+              {::grab/errors errors}))
           (throw
-           (ex-info
-            "Failed to store GraphQL document due to error"
-            {}
-            e)))))))
+            (ex-info
+              "Failed to store GraphQL document due to error"
+              {}
+              e)))))))
 
 (defn stored-document-put-handler [{::site/keys [uri db xt-node] :as req}]
   (let [document-str (some-> req :juxt.site.alpha/received-representation :juxt.http.alpha/body (String.))
 
         _ (when-not document-str
             (throw
-             (ex-info
-              "No document in request"
-              {::site/request-context (assoc req :ring.response/status 400)})))
+              (ex-info
+                "No document in request"
+                {::site/request-context (assoc req :ring.response/status 400)})))
 
         resource (xt/entity db uri)]
 
     (when (nil? resource)
       (throw
-       (ex-info
-        "GraphQL stored-document resource not configured"
-        {:uri uri
-         ::site/request-context (assoc req :ring.response/status 400)})))
+        (ex-info
+          "GraphQL stored-document resource not configured"
+          {:uri uri
+           ::site/request-context (assoc req :ring.response/status 400)})))
 
     ;; Validate resource
     (when-not (::site/graphql-schema resource)
       (throw
-       (ex-info
-        "Resource should have a :juxt.site.alpha/graphql-schema key"
-        {::site/resource resource
-         ::site/request-context (assoc req :ring.response/status 500)})))
+        (ex-info
+          "Resource should have a :juxt.site.alpha/graphql-schema key"
+          {::site/resource resource
+           ::site/request-context (assoc req :ring.response/status 500)})))
 
     (let [schema-id (::site/graphql-schema resource)
           schema (some-> db (xt/entity schema-id) ::site/graphql-compiled-schema)]
 
       (when-not schema
         (throw
-         (ex-info
-          "Cannot store a GraphQL document when the schema hasn't been added"
-          {::site/graph-schema schema-id
-           ::site/request-context (assoc req :ring.response/status 500)})))
+          (ex-info
+            "Cannot store a GraphQL document when the schema hasn't been added"
+            {::site/graph-schema schema-id
+             ::site/request-context (assoc req :ring.response/status 500)})))
 
       (try
         (let [m (stored-document-resource-map document-str schema)]
           (xt/await-tx
-           xt-node
-           (xt/submit-tx
             xt-node
-            [[:xtdb.api/put (into resource m)]])))
+            (xt/submit-tx
+              xt-node
+              [[:xtdb.api/put (into resource m)]])))
 
         (assoc req :ring.response/status 204)
 
         (catch clojure.lang.ExceptionInfo e
           (if-let [errors (::grab/errors (ex-data e))]
             (throw
-             ;; Throw but ignore the cause (since we pull out the key
-             ;; information from it)
-             (ex-info
-              "Errors in GraphQL document"
-              (cond-> {::site/request-context (assoc req :ring.response/status 400)}
-                (seq errors) (assoc ::grab/errors errors))))
+              ;; Throw but ignore the cause (since we pull out the key
+              ;; information from it)
+              (ex-info
+                "Errors in GraphQL document"
+                (cond-> {::site/request-context (assoc req :ring.response/status 400)}
+                  (seq errors) (assoc ::grab/errors errors))))
             (throw
-             (ex-info
-              "Failed to store GraphQL document due to error"
-              {::site/request-context (assoc req :ring.response/status 500)}
-              e))))))))
+              (ex-info
+                "Failed to store GraphQL document due to error"
+                {::site/request-context (assoc req :ring.response/status 500)}
+                e))))))))
 
 (defn graphql-query [{::site/keys [db] :as req} stored-query-id operation-name variables]
   (assert stored-query-id)
@@ -1051,10 +1048,10 @@
   (let [resource (xt/entity db stored-query-id)
         _ (when-not resource
             (throw
-             (ex-info
-              "GraphQL stored query not found"
-              {:stored-query-id stored-query-id
-               ::site/request-context (assoc req :ring.response/status 500)})))
+              (ex-info
+                "GraphQL stored query not found"
+                {:stored-query-id stored-query-id
+                 ::site/request-context (assoc req :ring.response/status 500)})))
 
         schema-id (::site/graphql-schema resource)
 

--- a/src/juxt/site/alpha/graphql_resolver.clj
+++ b/src/juxt/site/alpha/graphql_resolver.clj
@@ -34,10 +34,10 @@
       ;; Set empty strings to "true" rather than empty-string, to enable selmer
       ;; truthy on 'if'.
       (reduce-kv
-       (fn [acc k v]
-         (assoc acc k (if (str/blank? v) "true" v)))
-       {}
-       form))))
+        (fn [acc k v]
+          (assoc acc k (if (str/blank? v) "true" v)))
+        {}
+        form))))
 
 (defn query-parameters [args]
   (mapv (fn [[k v]] {"name" k "value" v}) (form args)))
@@ -53,8 +53,8 @@
 (defn df [dir]
   (when-let [out (:out (sh/sh "df" "--output=avail" dir))]
     (Long/parseLong
-     (str/trim
-      (second (str/split out #"\n"))))))
+      (str/trim
+        (second (str/split out #"\n"))))))
 
 (defn tx-log-avail [])
 
@@ -76,8 +76,8 @@
 (defn apis [{:keys [db]}]
   (let [openapis
         (for [[uri api] (xt/q
-                         db '{:find [openapi-uri openapi]
-                              :where [[openapi-uri :juxt.apex.alpha/openapi openapi]]})]
+                          db '{:find [openapi-uri openapi]
+                               :where [[openapi-uri :juxt.apex.alpha/openapi openapi]]})]
           {:xt/id uri
            :type "OPENAPI"
            :contents api})
@@ -126,18 +126,18 @@
        (let [node (:juxt.site.alpha.db/xt-node system)
              status (xt/status node)]
          (merge
-          (set/rename-keys
-           status
-           {:xtdb.version/version "version"
-            :xtdb.version/revision "revision"
-            :xtdb.index/index-version "indexVersion"
-            :xtdb.kv/kv-store "kvStore"
-            :xtdb.kv/estimate-num-keys "estimateNumKeys"
-            :xtdb.kv/size "kvSize"})
-          {"attributeStats"
-           (fn [_]
-             (for [[name frequency] (xt/attribute-stats node)]
-               {"attribute" (str name) "frequency" frequency}))})))
+           (set/rename-keys
+             status
+             {:xtdb.version/version "version"
+              :xtdb.version/revision "revision"
+              :xtdb.index/index-version "indexVersion"
+              :xtdb.kv/kv-store "kvStore"
+              :xtdb.kv/estimate-num-keys "estimateNumKeys"
+              :xtdb.kv/size "kvSize"})
+           {"attributeStats"
+            (fn [_]
+              (for [[name frequency] (xt/attribute-stats node)]
+                {"attribute" (str name) "frequency" frequency}))})))
 
      "version"
      {"gitSha" (fn [_] (git-sha))}
@@ -153,22 +153,22 @@
 
 (defn extract-errors-resolver [args]
   (some->>
-   args
-   :object-value
-   :juxt.site.alpha/errors
-   (map (fn [error]
-          (let [ex-data (:ex-data error)
-                graphql-type-name (::site/graphql-type ex-data "SiteGeneralError")]
-            (into
-             (into error {::site/graphql-type graphql-type-name})
-             (case graphql-type-name
-               "SiteGraphqlExecutionError"
-               (select-keys ex-data [::site/graphql-stored-query-resource-path
-                                     ::site/graphql-operation-name
-                                     ::site/graphql-variables
-                                     ::grab/errors])
-               {}
-               )))))))
+    args
+    :object-value
+    :juxt.site.alpha/errors
+    (map (fn [error]
+           (let [ex-data (:ex-data error)
+                 graphql-type-name (::site/graphql-type ex-data "SiteGeneralError")]
+             (into
+               (into error {::site/graphql-type graphql-type-name})
+               (case graphql-type-name
+                 "SiteGraphqlExecutionError"
+                 (select-keys ex-data [::site/graphql-stored-query-resource-path
+                                       ::site/graphql-operation-name
+                                       ::site/graphql-variables
+                                       ::grab/errors])
+                 {}
+                 )))))))
 
 (defn graphql-errors [args]
   (for [error (some-> args :object-value ::grab/errors)]

--- a/src/juxt/site/alpha/handler.clj
+++ b/src/juxt/site/alpha/handler.clj
@@ -46,11 +46,11 @@
   response header value, and others."
   [methods upper-case?]
   (->>
-   methods
-   seq
-   distinct
-   (map (comp (if upper-case? str/upper-case identity) name))
-   (str/join ", ")))
+    methods
+    seq
+    distinct
+    (map (comp (if upper-case? str/upper-case identity) name))
+    (str/join ", ")))
 
 (defn receive-representation
   "Check and load the representation enclosed in the request message payload."
@@ -59,20 +59,20 @@
   (let [content-length
         (try
           (some->
-           (get-in req [:ring.request/headers "content-length"])
-           (Long/parseLong))
+            (get-in req [:ring.request/headers "content-length"])
+            (Long/parseLong))
           (catch NumberFormatException e
             (throw
-             (ex-info
-              "Bad content length"
-              {::site/request-context (assoc req :ring.response/status 400)}
-              e))))]
+              (ex-info
+                "Bad content length"
+                {::site/request-context (assoc req :ring.response/status 400)}
+                e))))]
 
     (when (nil? content-length)
       (throw
-       (ex-info
-        "No Content-Length header found"
-        {::site/request-context (assoc req :ring.response/status 411)})))
+        (ex-info
+          "No Content-Length header found"
+          {::site/request-context (assoc req :ring.response/status 411)})))
 
     ;; Protects resources from PUTs that are too large. If you need to
     ;; exceed this limitation, explicitly declare ::spin/max-content-length in
@@ -80,30 +80,30 @@
     (when-let [max-content-length (get resource ::http/max-content-length (Math/pow 2 24))] ;;16MB
       (when (> content-length max-content-length)
         (throw
-         (ex-info
-          "Payload too large"
-          {::site/request-context (assoc req :ring.response/status 413)}))))
+          (ex-info
+            "Payload too large"
+            {::site/request-context (assoc req :ring.response/status 413)}))))
 
     (when-not (:ring.request/body req)
       (throw
-       (ex-info
-        "No body in request"
-        {::site/request-context (assoc req :ring.response/status 400)})))
+        (ex-info
+          "No body in request"
+          {::site/request-context (assoc req :ring.response/status 400)})))
 
     (let [decoded-representation
           (decode-maybe
 
-           ;; See Section 3.1.1.5, RFC 7231 as to why content-type defaults
-           ;; to application/octet-stream
-           (cond-> {::http/content-type "application/octet-stream"}
-             (contains? (:ring.request/headers req) "content-type")
-             (assoc ::http/content-type (get-in req [:ring.request/headers "content-type"]))
+            ;; See Section 3.1.1.5, RFC 7231 as to why content-type defaults
+            ;; to application/octet-stream
+            (cond-> {::http/content-type "application/octet-stream"}
+              (contains? (:ring.request/headers req) "content-type")
+              (assoc ::http/content-type (get-in req [:ring.request/headers "content-type"]))
 
-             (contains? (:ring.request/headers req) "content-encoding")
-             (assoc ::http/content-encoding (get-in req [:ring.request/headers "content-encoding"]))
+              (contains? (:ring.request/headers req) "content-encoding")
+              (assoc ::http/content-encoding (get-in req [:ring.request/headers "content-encoding"]))
 
-             (contains? (:ring.request/headers req) "content-language")
-             (assoc ::http/content-language (get-in req [:ring.request/headers "content-language"]))))]
+              (contains? (:ring.request/headers req) "content-language")
+              (assoc ::http/content-language (get-in req [:ring.request/headers "content-language"]))))]
 
       ;; TODO: Someday there should be a functions that could be specified to
       ;; handle conversions as described in RFC 7231 Section 4.3.4
@@ -124,85 +124,85 @@
             (cond
               (= (:juxt.pick.alpha/content-type-qvalue request-rep) 0.0)
               (throw
-               (ex-info
-                "The content-type of the request payload is not supported by the resource"
-                {::acceptable acceptable
-                 ::content-type (get request-rep "content-type")
-                 ::site/request-context (assoc req :ring.response/status 415)}))
+                (ex-info
+                  "The content-type of the request payload is not supported by the resource"
+                  {::acceptable acceptable
+                   ::content-type (get request-rep "content-type")
+                   ::site/request-context (assoc req :ring.response/status 415)}))
 
               (and
-               (= "text" (get-in request-rep [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/type]))
-               (get prefs "accept-charset")
-               (not (contains? (get-in request-rep [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/parameter-map]) "charset")))
+                (= "text" (get-in request-rep [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/type]))
+                (get prefs "accept-charset")
+                (not (contains? (get-in request-rep [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/parameter-map]) "charset")))
               (throw
-               (ex-info
-                "The Content-Type header in the request is a text type and is required to specify its charset as a media-type parameter"
-                {::acceptable acceptable
-                 ::content-type (get request-rep "content-type")
-                 ::site/request-context (assoc req :ring.response/status 415)}))
+                (ex-info
+                  "The Content-Type header in the request is a text type and is required to specify its charset as a media-type parameter"
+                  {::acceptable acceptable
+                   ::content-type (get request-rep "content-type")
+                   ::site/request-context (assoc req :ring.response/status 415)}))
 
               (= (:juxt.pick.alpha/charset-qvalue request-rep) 0.0)
               (throw
-               (ex-info
-                "The charset of the Content-Type header in the request is not supported by the resource"
-                {::acceptable acceptable
-                 ::content-type (get request-rep "content-type")
-                 ::site/request-context (assoc req :ring.response/status 415)}))))
+                (ex-info
+                  "The charset of the Content-Type header in the request is not supported by the resource"
+                  {::acceptable acceptable
+                   ::content-type (get request-rep "content-type")
+                   ::site/request-context (assoc req :ring.response/status 415)}))))
 
           (when (get prefs "accept-encoding")
             (cond
               (= (:juxt.pick.alpha/content-encoding-qvalue request-rep) 0.0)
               (throw
-               (ex-info
-                "The content-encoding in the request is not supported by the resource"
-                {::acceptable acceptable
-                 ::content-encoding (get-in req [:ring.request/headers "content-encoding"] "identity")
-                 ::site/request-context (assoc req :ring.response/status 409)}))))
+                (ex-info
+                  "The content-encoding in the request is not supported by the resource"
+                  {::acceptable acceptable
+                   ::content-encoding (get-in req [:ring.request/headers "content-encoding"] "identity")
+                   ::site/request-context (assoc req :ring.response/status 409)}))))
 
           (when (get prefs "accept-language")
             (cond
               (not (contains? (:ring.response/headers req) "content-language"))
               (throw
-               (ex-info
-                "Request must contain Content-Language header"
-                {::acceptable acceptable
-                 ::content-language (get-in req [:ring.request/headers "content-language"])
-                 ::site/request-context (assoc req :ring.response/status 409)}))
+                (ex-info
+                  "Request must contain Content-Language header"
+                  {::acceptable acceptable
+                   ::content-language (get-in req [:ring.request/headers "content-language"])
+                   ::site/request-context (assoc req :ring.response/status 409)}))
 
               (= (:juxt.pick.alpha/content-language-qvalue request-rep) 0.0)
               (throw
-               (ex-info
-                "The content-language in the request is not supported by the resource"
-                {::acceptable acceptable
-                 ::content-language (get-in req [:ring.request/headers "content-language"])
-                 ::site/request-context (assoc req :ring.response/status 415)}))))))
+                (ex-info
+                  "The content-language in the request is not supported by the resource"
+                  {::acceptable acceptable
+                   ::content-language (get-in req [:ring.request/headers "content-language"])
+                   ::site/request-context (assoc req :ring.response/status 415)}))))))
 
       (when (get-in req [:ring.request/headers "content-range"])
         (throw
-         (ex-info
-          "Content-Range header not allowed on a PUT request"
-          {::site/request-context (assoc req :ring.response/status 400)})))
+          (ex-info
+            "Content-Range header not allowed on a PUT request"
+            {::site/request-context (assoc req :ring.response/status 400)})))
 
       (with-open [in (:ring.request/body req)]
         (let [body (.readNBytes in content-length)
               content-type (:juxt.reap.alpha.rfc7231/content-type decoded-representation)]
 
           (merge
-           decoded-representation
-           {::http/content-length content-length
-            ::http/last-modified start-date}
+            decoded-representation
+            {::http/content-length content-length
+             ::http/last-modified start-date}
 
-           (if (and
-                (= (:juxt.reap.alpha.rfc7231/type content-type) "text")
-                (nil? (get decoded-representation ::http/content-encoding)))
-             (let [charset
-                   (get-in decoded-representation
-                           [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/parameter-map "charset"])]
-               (merge
-                {::http/content (new String body (or charset "utf-8"))}
-                (when charset {::http/charset charset})))
+            (if (and
+                  (= (:juxt.reap.alpha.rfc7231/type content-type) "text")
+                  (nil? (get decoded-representation ::http/content-encoding)))
+              (let [charset
+                    (get-in decoded-representation
+                            [:juxt.reap.alpha.rfc7231/content-type :juxt.reap.alpha.rfc7231/parameter-map "charset"])]
+                (merge
+                  {::http/content (new String body (or charset "utf-8"))}
+                  (when charset {::http/charset charset})))
 
-             {::http/body body})))))))
+              {::http/body body})))))))
 
 (defn GET [req]
   (conditional/evaluate-preconditions! req)
@@ -218,8 +218,8 @@
         existing (xt/entity db location)]
 
     (->> (xt/submit-tx
-          xt-node
-          [[:xtdb.api/put (merge {:xt/id location} request-instance)]])
+           xt-node
+           [[:xtdb.api/put (merge {:xt/id location} request-instance)]])
          (xt/await-tx xt-node))
 
     (into req {:ring.response/status (if existing 204 201)
@@ -231,12 +231,12 @@
         {::site/keys [resource]} resource-state
         existing (xt/entity db resource)]
     (->> (xt/submit-tx
-          xt-node
-          [[:xtdb.api/put
-            (merge
-             {:xt/id resource}
-             ;; ::site/resource = :xt/id, no need to duplicate
-             (dissoc resource-state ::site/resource))]])
+           xt-node
+           [[:xtdb.api/put
+             (merge
+               {:xt/id resource}
+               ;; ::site/resource = :xt/id, no need to duplicate
+               (dissoc resource-state ::site/resource))]])
          (xt/await-tx xt-node))
 
     (into req {:ring.response/status (if existing 204 201)})))
@@ -245,8 +245,8 @@
 
 (defn POST [{::site/keys [resource request-id] :as req}]
   (let [rep (->
-             (receive-representation req)
-             (assoc ::site/request request-id))
+              (receive-representation req)
+              (assoc ::site/request request-id))
         req (assoc req ::site/received-representation rep)
         post-fn (::site/post-fn resource)
         post
@@ -256,31 +256,31 @@
           (symbol? post-fn)
           (try
             (or
-             (requiring-resolve post-fn)
-             (throw
-              (ex-info
-               (format "Requiring resolve of %s returned nil" post-fn)
-               {:post-fn post-fn
-                ::site/request-context (assoc req :ring.response/status 500)})))
+              (requiring-resolve post-fn)
+              (throw
+                (ex-info
+                  (format "Requiring resolve of %s returned nil" post-fn)
+                  {:post-fn post-fn
+                   ::site/request-context (assoc req :ring.response/status 500)})))
             (catch Exception e
               (throw
-               (ex-info
-                (format "post-fn '%s' is not resolvable" post-fn)
-                {::post-fn post-fn
-                 ::site/request-context (assoc req :ring.response/status 500)}
-                e))))
+                (ex-info
+                  (format "post-fn '%s' is not resolvable" post-fn)
+                  {::post-fn post-fn
+                   ::site/request-context (assoc req :ring.response/status 500)}
+                  e))))
 
           (nil? post-fn)
           (throw
-           (ex-info
-            "Resource allows POST but doesn't have a post-fn function"
-            {::site/request-context (assoc req :ring.response/status 500)}))
+            (ex-info
+              "Resource allows POST but doesn't have a post-fn function"
+              {::site/request-context (assoc req :ring.response/status 500)}))
 
           :else
           (throw
-           (ex-info
-            (format "post-fn is neither a function or a symbol, but type '%s'" (type post-fn))
-            {::site/request-context (assoc req :ring.response/status 500)})))]
+            (ex-info
+              (format "post-fn is neither a function or a symbol, but type '%s'" (type post-fn))
+              {::site/request-context (assoc req :ring.response/status 500)})))]
 
     (assert post)
     (post req)))
@@ -299,33 +299,33 @@
             (symbol? put-fn)
             (try
               (or
-               (requiring-resolve put-fn)
-               (throw (ex-info (format "Requiring resolve of %s returned nil" put-fn) {:put-fn put-fn})))
+                (requiring-resolve put-fn)
+                (throw (ex-info (format "Requiring resolve of %s returned nil" put-fn) {:put-fn put-fn})))
               (catch Exception e
                 (throw
-                 (ex-info
-                  (format "put-fn '%s' is not resolvable" put-fn)
-                  {::put-fn put-fn
-                   ::site/request-context (assoc req :ring.response/status 500)}
-                  e))))
+                  (ex-info
+                    (format "put-fn '%s' is not resolvable" put-fn)
+                    {::put-fn put-fn
+                     ::site/request-context (assoc req :ring.response/status 500)}
+                    e))))
             (nil? put-fn)
             (throw
-             (ex-info
-              "Resource allows PUT but doesn't contain a put-fn function"
-              {::site/request-context (assoc req :ring.response/status 500)}))
+              (ex-info
+                "Resource allows PUT but doesn't contain a put-fn function"
+                {::site/request-context (assoc req :ring.response/status 500)}))
 
             :else
             (throw
-             (ex-info
-              (format "put-fn is neither a function or a symbol, but type '%s'" (type put-fn))
-              {::site/request-context (assoc req :ring.response/status 500)})))]
+              (ex-info
+                (format "put-fn is neither a function or a symbol, but type '%s'" (type put-fn))
+                {::site/request-context (assoc req :ring.response/status 500)})))]
       (if-let [response (put req)]
         response
         (throw
-         (ex-info
-          "put-fn returned a nil response"
-          {:put-fn put-fn
-           ::site/request-context (assoc req :ring.response/status 500)}))))))
+          (ex-info
+            "put-fn returned a nil response"
+            {:put-fn put-fn
+             ::site/request-context (assoc req :ring.response/status 500)}))))))
 
 (defn PATCH [{::site/keys [resource] :as req}]
   (let [rep (receive-representation req) _ (assert rep)
@@ -337,9 +337,9 @@
       (fn? patch-fn) (patch-fn req)
       :else
       (throw
-       (ex-info
-        "Resource allows PATCH but doesn't contain have a patch-fn function"
-        {::site/request-context (assoc req :ring.response/status 500)})))))
+        (ex-info
+          "Resource allows PATCH but doesn't contain have a patch-fn function"
+          {::site/request-context (assoc req :ring.response/status 500)})))))
 
 (defn DELETE [{::site/keys [xt-node uri] :as req}]
   (let [tx (xt/submit-tx xt-node [[:xtdb.api/delete uri]])]
@@ -353,10 +353,10 @@
 
         [resource-origin allow-origin]
         (or
-         (when-let [ro (get access-control-allow-origins request-origin)]
-           [ro request-origin])
-         (when-let [ro (get access-control-allow-origins "*")]
-           [ro "*"]))
+          (when-let [ro (get access-control-allow-origins request-origin)]
+            [ro request-origin])
+          (when-let [ro (get access-control-allow-origins "*")]
+            [ro "*"]))
 
         access-control-allow-methods
         (get resource-origin ::site/access-control-allow-methods)
@@ -380,27 +380,27 @@
 
       access-control-allow-methods
       (update
-       :ring.response/headers
-       (fn [headers]
-         (cond-> headers
-           allow-origin (assoc "access-control-allow-origin" allow-origin)
-           access-control-allow-methods (assoc "access-control-allow-methods" (join-keywords access-control-allow-methods true))
-           access-control-allow-headers (assoc "access-control-allow-headers" (join-keywords access-control-allow-headers false))
-           access-control-allow-credentials (assoc "access-control-allow-credentials" access-control-allow-credentials)))))))
+        :ring.response/headers
+        (fn [headers]
+          (cond-> headers
+            allow-origin (assoc "access-control-allow-origin" allow-origin)
+            access-control-allow-methods (assoc "access-control-allow-methods" (join-keywords access-control-allow-methods true))
+            access-control-allow-headers (assoc "access-control-allow-headers" (join-keywords access-control-allow-headers false))
+            access-control-allow-credentials (assoc "access-control-allow-credentials" access-control-allow-credentials)))))))
 
 (defn PROPFIND [req]
   (dave.methods/propfind req))
 
 (defn MKCOL [{::site/keys [xt-node uri]}]
   (let [tx (xt/submit-tx
-            xt-node
-            [[:xtdb.api/put
-              {:xt/id uri
-               ::dave/resource-type :collection
-               ::http/methods #{:get :head :options :propfind}
-               ::http/content-type "text/html;charset=utf-8"
-               ::http/content "<h1>Index</h1>\r\n"
-               ::http/options {"DAV" "1"}}]])]
+             xt-node
+             [[:xtdb.api/put
+               {:xt/id uri
+                ::dave/resource-type :collection
+                ::http/methods #{:get :head :options :propfind}
+                ::http/content-type "text/html;charset=utf-8"
+                ::http/content "<h1>Index</h1>\r\n"
+                ::http/options {"DAV" "1"}}]])]
     (xt/await-tx xt-node tx))
   {:ring.response/status 201
    :ring.response/headers {}})
@@ -414,13 +414,13 @@
 (defn wrap-method-not-implemented? [h]
   (fn [{:ring.request/keys [method] :as req}]
     (when-not (contains?
-               #{:get :head :post :put :delete :options
-                 :patch
-                 :mkcol :propfind} method)
+                #{:get :head :post :put :delete :options
+                  :patch
+                  :mkcol :propfind} method)
       (throw
-       (ex-info
-        "Method not implemented"
-        {::site/request-context (assoc req :ring.response/status 501)})))
+        (ex-info
+          "Method not implemented"
+          {::site/request-context (assoc req :ring.response/status 501)})))
     (h req)))
 
 (defn wrap-locate-resource [h]
@@ -434,14 +434,14 @@
     (when (= (::site/type resource) "Redirect")
       (let [status (case method (:get :head) 302 307)]
         (throw
-         (ex-info
-          "Redirect"
-          {:location (::site/location resource)
-           ::site/request-context
-           (-> req
-               (assoc :ring.response/status status)
-               (update :ring.response/headers
-                       assoc "location" (::site/location resource)))}))))
+          (ex-info
+            "Redirect"
+            {:location (::site/location resource)
+             ::site/request-context
+             (-> req
+                 (assoc :ring.response/status status)
+                 (update :ring.response/headers
+                         assoc "location" (::site/location resource)))}))))
     (h req)))
 
 (defn wrap-find-current-representations
@@ -451,9 +451,9 @@
       (let [cur-reps (seq (conneg/current-representations req))]
         (when (and (#{:get :head} method) (empty? cur-reps))
           (throw
-           (ex-info
-            "Not Found"
-            {::site/request-context (assoc req :ring.response/status 404)})))
+            (ex-info
+              "Not Found"
+              {::site/request-context (assoc req :ring.response/status 404)})))
         (h (assoc req ::site/current-representations cur-reps)))
       (h req))))
 
@@ -463,8 +463,8 @@
       (h (cond-> req
            (seq cur-reps)
            (assoc
-            ::site/selected-representation
-            (conneg/negotiate-representation req cur-reps)))))))
+             ::site/selected-representation
+             (conneg/negotiate-representation req cur-reps)))))))
 
 (defn wrap-authenticate [h]
   (fn [{:ring.request/keys [method] :as req}]
@@ -482,12 +482,12 @@
           {'subject subject
            'resource (dissoc resource ::http/body ::http/content)
            'request (select-keys
-                     req
-                     [:ring.request/headers :ring.request/method :ring.request/path
-                      :ring.request/query :ring.request/protocol :ring.request/remote-addr
-                      :ring.request/scheme :ring.request/server-name :ring.request/server-post
-                      :ring.request/ssl-client-cert
-                      ::site/uri])
+                      req
+                      [:ring.request/headers :ring.request/method :ring.request/path
+                       :ring.request/query :ring.request/protocol :ring.request/remote-addr
+                       :ring.request/scheme :ring.request/server-name :ring.request/server-post
+                       :ring.request/ssl-client-cert
+                       ::site/uri])
            'representation (dissoc resource ::http/body ::http/content)
            'environment {}}
 
@@ -507,9 +507,9 @@
                  (not= (::pass/access authz) ::pass/approved))
         (let [status (if-not (::pass/user subject) 401 403)]
           (throw
-           (ex-info
-            (case status 401  "Unauthorized" 403 "Forbidden")
-            {::site/request-context (assoc req :ring.response/status status)}))))
+            (ex-info
+              (case status 401  "Unauthorized" 403 "Forbidden")
+              {::site/request-context (assoc req :ring.response/status status)}))))
       (h req))))
 
 (defn wrap-method-not-allowed? [h]
@@ -518,15 +518,15 @@
       (let [allowed-methods (set (::http/methods resource))]
         (when-not (contains? allowed-methods method)
           (throw
-           (ex-info
-            "Method not allowed"
-            {:method method
-             ::site/allowed-methods allowed-methods
-             ::site/request-context
-             (into
-              req
-              {:ring.response/status 405
-               :ring.response/headers {"allow" (join-keywords allowed-methods true)}})})))
+            (ex-info
+              "Method not allowed"
+              {:method method
+               ::site/allowed-methods allowed-methods
+               ::site/request-context
+               (into
+                 req
+                 {:ring.response/status 405
+                  :ring.response/headers {"allow" (join-keywords allowed-methods true)}})})))
         (h (assoc req ::site/allowed-methods allowed-methods)))
       (h req))))
 
@@ -554,17 +554,17 @@
           triggers
           (map first
                (xt/q db '{:find [rule]
-                         :where [[rule ::site/type "Trigger"]]}))
+                          :where [[rule ::site/type "Trigger"]]}))
 
           request-context
           {'subject subject
            'request (select-keys
-                     req
-                     [:ring.request/headers :ring.request/method :ring.request/path
-                      :ring.request/query :ring.request/protocol :ring.request/remote-addr
-                      :ring.request/scheme :ring.request/server-name :ring.request/server-post
-                      :ring.request/ssl-client-cert
-                      ::site/uri])
+                      req
+                      [:ring.request/headers :ring.request/method :ring.request/path
+                       :ring.request/query :ring.request/protocol :ring.request/remote-addr
+                       :ring.request/scheme :ring.request/server-name :ring.request/server-post
+                       :ring.request/ssl-client-cert
+                       ::site/uri])
            'environment {}}]
 
       (try
@@ -615,9 +615,9 @@
         (assoc-when-some "vary" (some-> rep ::http/vary))
         (assoc-when-some "content-length"
                          (or
-                          (some-> rep ::http/content-length str)
-                          (when (counted? body)
-                            (some-> body count str))))
+                           (some-> rep ::http/content-length str)
+                           (when (counted? body)
+                             (some-> body count str))))
         (assoc-when-some "content-range" (::http/content-range rep))
         (assoc-when-some "trailer" (::http/trailer rep))
         (assoc-when-some "transfer-encoding" (::http/transfer-encoding rep)))))
@@ -637,25 +637,25 @@
       redact
       (dissoc ::site/xt-node ::site/db :ring.request/body :ring.response/body)
       (util/deep-replace
-       (fn [form]
-         (cond-> form
-           (and (string? form) (>= (count form) 1024))
-           (subs 0 1024)
+        (fn [form]
+          (cond-> form
+            (and (string? form) (>= (count form) 1024))
+            (subs 0 1024)
 
-           (and (vector? form) (>= (count form) 64))
-           (subvec 0 64)
+            (and (vector? form) (>= (count form) 64))
+            (subvec 0 64)
 
-           (and (list? form) (>= (count form) 64))
-           (#(take 64 %)))))))
+            (and (list? form) (>= (count form) 64))
+            (#(take 64 %)))))))
 
 (defn log-request! [{:ring.request/keys [method] :as req}]
   (assert method)
   (log/infof
-   "%-7s %s %s %d"
-   (str/upper-case (name method))
-   (:ring.request/path req)
-   (:ring.request/protocol req)
-   (:ring.response/status req)))
+    "%-7s %s %s %d"
+    (str/upper-case (name method))
+    (:ring.request/path req)
+    (:ring.request/protocol req)
+    (:ring.response/status req)))
 
 (defn respond
   [{::site/keys [selected-representation start-date base-uri request-id]
@@ -677,20 +677,20 @@
                 :ring.response/headers
                 assoc "date" (format-http-date start-date))
 
-        request-id
-        (update :ring.response/headers
-                assoc "site-request-id"
-                (cond-> request-id
-                  ;; Not sure I like this shortening, it's inconvenient to have
-                  ;; to prepend the base-uri each time
-                  #_(.startsWith request-id base-uri)
-                  #_(subs (count base-uri))))
+      request-id
+      (update :ring.response/headers
+              assoc "site-request-id"
+              (cond-> request-id
+                ;; Not sure I like this shortening, it's inconvenient to have
+                ;; to prepend the base-uri each time
+                #_(.startsWith request-id base-uri)
+                #_(subs (count base-uri))))
 
-        selected-representation
-        (update :ring.response/headers
-                representation-headers selected-representation body)
+      selected-representation
+      (update :ring.response/headers
+              representation-headers selected-representation body)
 
-        (= method :head) (dissoc :ring.response/body))))
+      (= method :head) (dissoc :ring.response/body))))
 
 (defn wrap-initialize-response [h]
   (fn [req]
@@ -760,12 +760,12 @@
   [e]
   (let [cause (.getCause e)]
     (cons
-     (cond->
-         {:message (.getMessage e)
-          :stack-trace (.getStackTrace e)}
-       (instance? clojure.lang.ExceptionInfo e)
-       (assoc :ex-data (dissoc (ex-data e) ::site/request-context)))
-     (when cause (errors-with-causes cause)))))
+      (cond->
+          {:message (.getMessage e)
+           :stack-trace (.getStackTrace e)}
+        (instance? clojure.lang.ExceptionInfo e)
+        (assoc :ex-data (dissoc (ex-data e) ::site/request-context)))
+      (when cause (errors-with-causes cause)))))
 
 (defn put-error-representation
   "If method is PUT"
@@ -773,10 +773,10 @@
   (let [{::http/keys [put-error-representations]} resource
         put-error-representations
         (filter
-         (fn [rep]
-           (if-some [applies-to (:ring.response/status rep)]
-             (= applies-to status)
-             true)) put-error-representations)]
+          (fn [rep]
+            (if-some [applies-to (:ring.response/status rep)]
+              (= applies-to status)
+              true)) put-error-representations)]
 
     (when (seq put-error-representations)
       (some-> (conneg/negotiate-representation req put-error-representations)
@@ -789,10 +789,10 @@
   (let [{::http/keys [post-error-representations]} resource
         post-error-representations
         (filter
-         (fn [rep]
-           (if-some [applies-to (:ring.response/status rep)]
-             (= applies-to status)
-             true)) post-error-representations)]
+          (fn [rep]
+            (if-some [applies-to (:ring.response/status rep)]
+              (= applies-to status)
+              true)) post-error-representations)]
 
     (when (seq post-error-representations)
       (some-> (conneg/negotiate-representation req post-error-representations)
@@ -815,10 +815,10 @@
   variables to determine the resource to use."
   [{::site/keys [db]} status]
   (when-let [res (ffirst
-            (xt/q db '{:find [(pull er [*])]
-                      :where [[er ::site/type "ErrorResource"]
-                              [er :ring.response/status status]]
-                      :in [status]} status))]
+                   (xt/q db '{:find [(pull er [*])]
+                              :where [[er ::site/type "ErrorResource"]
+                                      [er :ring.response/status status]]
+                              :in [status]} status))]
     (log/tracef "ErrorResource found for status %d: %s" status res)
     res))
 
@@ -850,9 +850,9 @@
 
             error-representations
             (conneg/current-representations
-             (assoc req
-                    ::site/resource er
-                    ::site/uri (:xt/id er)))]
+              (assoc req
+                     ::site/resource er
+                     ::site/uri (:xt/id er)))]
 
         (when (seq error-representations)
           (some-> (conneg/negotiate-representation req error-representations)
@@ -871,16 +871,16 @@
                request-id (str (format "<p><a href=\"%s\" target=\"_site_error\">%s</a></p>\r\n" request-id "Error")))
              "</body>\r\n")]
     (respond
-     (into
-      req
-      {:ring.response/status 500
-       :ring.response/body default-body
-       ::site/errors (errors-with-causes e)
-       ::site/selected-representation
-       {::http/content-type "text/html;charset=utf-8"
-        ::http/content-length (count default-body)
-        :ring.response/body default-body}
-       }))))
+      (into
+        req
+        {:ring.response/status 500
+         :ring.response/body default-body
+         ::site/errors (errors-with-causes e)
+         ::site/selected-representation
+         {::http/content-type "text/html;charset=utf-8"
+          ::http/content-length (count default-body)
+          :ring.response/body default-body}
+         }))))
 
 (defn error-response
   "Respond with the given error"
@@ -894,51 +894,51 @@
 
         representation
         (or
-         (when (= method :put) (put-error-representation req e))
-         (when (= method :post) (post-error-representation req e))
-         (error-resource-representation req e)
+          (when (= method :put) (put-error-representation req e))
+          (when (= method :post) (post-error-representation req e))
+          (error-resource-representation req e)
 
-         ;; Some default representations for errors
-         (some->
-          (conneg/negotiate-representation
-           req
-           [(let [content
-                  ;; We don't want to provide much information here, we don't
-                  ;; know much about the recipient, only that they're probably
-                  ;; using a web browser. We provide a link to the error
-                  ;; resource, because that will be subject to authorization
-                  ;; checks. So authorized users get to see extensive error
-                  ;; information, unauthorized users don't.
-                  (cond-> (str (status-message status) "\r\n")
-                    request-id (str (format "<a href=\"%s\" target=\"_site_error\">%s</a>\r\n" request-id "Error")))]
-              {::http/content-type "text/html;charset=utf-8"
-               ::http/content-length (count content)
-               ::http/content content})
-            (let [content
-                  (str (status-message status)
-                       ;; For text/plain we might be using the site tool. Here,
-                       ;; we decide that providing a little more context to the
-                       ;; user outweighs the need to restrict information about
-                       ;; the underlying implementation.
-                       " – " (.getMessage e) "\r\n\r\n")]
-              {::http/content-type "text/plain;charset=utf-8"
-               ::http/content-length (count content)
-               ::http/content content})])
+          ;; Some default representations for errors
+          (some->
+            (conneg/negotiate-representation
+              req
+              [(let [content
+                     ;; We don't want to provide much information here, we don't
+                     ;; know much about the recipient, only that they're probably
+                     ;; using a web browser. We provide a link to the error
+                     ;; resource, because that will be subject to authorization
+                     ;; checks. So authorized users get to see extensive error
+                     ;; information, unauthorized users don't.
+                     (cond-> (str (status-message status) "\r\n")
+                       request-id (str (format "<a href=\"%s\" target=\"_site_error\">%s</a>\r\n" request-id "Error")))]
+                 {::http/content-type "text/html;charset=utf-8"
+                  ::http/content-length (count content)
+                  ::http/content content})
+               (let [content
+                     (str (status-message status)
+                          ;; For text/plain we might be using the site tool. Here,
+                          ;; we decide that providing a little more context to the
+                          ;; user outweighs the need to restrict information about
+                          ;; the underlying implementation.
+                          " – " (.getMessage e) "\r\n\r\n")]
+                 {::http/content-type "text/plain;charset=utf-8"
+                  ::http/content-length (count content)
+                  ::http/content content})])
 
-          ;; This is an error, it won't be cached, it isn't negotiable 'content'
-          ;; so the Vary header isn't deemed applicable. Let's not set it.
-          (dissoc ::http/vary)))
+            ;; This is an error, it won't be cached, it isn't negotiable 'content'
+            ;; so the Vary header isn't deemed applicable. Let's not set it.
+            (dissoc ::http/vary)))
 
         error-resource (merge
-                        {:ring.response/status 500
-                         ::site/errors (errors-with-causes e)}
-                        (dissoc req ::site/request-context)
-                        ;; For the error itself
-                        {::site/selected-representation representation})
+                         {:ring.response/status 500
+                          ::site/errors (errors-with-causes e)}
+                         (dissoc req ::site/request-context)
+                         ;; For the error itself
+                         {::site/selected-representation representation})
 
         error-resource (assoc
-                        error-resource
-                        ::site/status-message (status-message (:ring.response/status error-resource)))
+                         error-resource
+                         ::site/status-message (status-message (:ring.response/status error-resource)))
 
         response (try
                    (response/add-payload error-resource)
@@ -983,8 +983,8 @@
               (error-response rc e))
 
             (error-response
-             req
-             (ex-info "ExceptionInfo caught, but with an invalid request-context attached" {::site/request-context rc} e)))))
+              req
+              (ex-info "ExceptionInfo caught, but with an invalid request-context attached" {::site/request-context rc} e)))))
 
       (catch Throwable t (respond-internal-error req t))
       (finally (org.slf4j.MDC/clear)))))
@@ -1015,7 +1015,7 @@
 (defn new-request-id [base-uri]
   (str base-uri "/_site/requests/"
        (subs (util/hexdigest
-              (.getBytes (str (java.util.UUID/randomUUID)) "US-ASCII")) 0 24)))
+               (.getBytes (str (java.util.UUID/randomUUID)) "US-ASCII")) 0 24)))
 
 (defn normalize-path
   "Normalize path prior to constructing URL used for resource lookup. This is to
@@ -1054,28 +1054,28 @@
           scheme+authority
           (or uri-prefix
               (->
-               (let [{::rfc7230/keys [host]}
-                     (host-header-parser
-                      (re/input
-                       (or
-                        (get-in req [:ring.request/headers "x-forwarded-host"])
-                        (get-in req [:ring.request/headers "host"]))))]
-                 (str (or (get-in req [:ring.request/headers "x-forwarded-proto"])
-                          (name scheme))
-                      "://" host))
-               (str/lower-case)         ; See Section 6.2.2.1 of RFC 3986
-               (http-scheme-normalize scheme)))
+                (let [{::rfc7230/keys [host]}
+                      (host-header-parser
+                        (re/input
+                          (or
+                            (get-in req [:ring.request/headers "x-forwarded-host"])
+                            (get-in req [:ring.request/headers "host"]))))]
+                  (str (or (get-in req [:ring.request/headers "x-forwarded-proto"])
+                           (name scheme))
+                       "://" host))
+                (str/lower-case)         ; See Section 6.2.2.1 of RFC 3986
+                (http-scheme-normalize scheme)))
 
           ;; The scheme+authority is already normalized (by transforming to
           ;; lower-case). The path, however, needs to be normalized here.
           uri (str scheme+authority (normalize-path (:ring.request/path req)))
 
           req (into req (merge
-                         {::site/start-date (java.util.Date.)
-                          ::site/request-id req-id
-                          ::site/uri uri
-                          ::site/db db}
-                         (dissoc opts ::site/uri-prefix)))]
+                          {::site/start-date (java.util.Date.)
+                           ::site/request-id req-id
+                           ::site/uri uri
+                           ::site/db db}
+                          (dissoc opts ::site/uri-prefix)))]
 
       ;; The Ring request map becomes the container for all state collected
       ;; along the request processing pathway.
@@ -1102,15 +1102,15 @@
               :ssl-client-cert :ring.request/ssl-client-cert}]
 
       (-> (reduce-kv
-           (fn [acc k v]
-             (let [k2 (get mp k)]
-               (cond-> acc k2 (assoc k2 v))))
-           {} req)
+            (fn [acc k v]
+              (let [k2 (get mp k)]
+                (cond-> acc k2 (assoc k2 v))))
+            {} req)
           (h)
           (select-keys
-           [:ring.response/status
-            :ring.response/headers
-            :ring.response/body])
+            [:ring.response/status
+             :ring.response/headers
+             :ring.response/body])
           (set/rename-keys {:ring.response/status :status
                             :ring.response/headers :headers
                             :ring.response/body :body})))))
@@ -1129,15 +1129,15 @@
         (let [{:ring.request/keys [method] ::site/keys [xt-node]} req]
           (when (or (= method :post) (= method :put))
             (xt/submit-tx
-             xt-node
-             [[:xtdb.api/put (-> req ->storable
-                                (select-keys [:juxt.pass.alpha/subject
-                                              ::site/date
-                                              ::site/uri
-                                              :ring.request/method
-                                              :ring.response/status])
-                                (assoc :xt/id req-id
-                                       ::site/type "Request"))]]))))
+              xt-node
+              [[:xtdb.api/put (-> req ->storable
+                                  (select-keys [:juxt.pass.alpha/subject
+                                                ::site/date
+                                                ::site/uri
+                                                :ring.request/method
+                                                :ring.response/status])
+                                  (assoc :xt/id req-id
+                                         ::site/type "Request"))]]))))
       req)))
 
 (defn wrap-log-request [h]
@@ -1163,12 +1163,12 @@
   (fn [req]
     (when-not (service-available? req)
       (throw
-       (ex-info
-        "Service unavailable"
-        {::site/request-context
-         (-> req
-             (into {:ring.response/status 503})
-             (assoc-in [:ring.response/headers "retry-after"] "120"))})))
+        (ex-info
+          "Service unavailable"
+          {::site/request-context
+           (-> req
+               (into {:ring.response/status 503})
+               (assoc-in [:ring.response/headers "retry-after"] "120"))})))
     (h req)))
 
 (defn make-pipeline

--- a/src/juxt/site/alpha/repl.clj
+++ b/src/juxt/site/alpha/repl.clj
@@ -179,6 +179,11 @@
       :else
       nil)))
 
+(defn- submit-and-wait-tx
+  [node tx]
+  (let [tx-id (xt/submit-tx node tx)]
+    (xt/await-tx node tx-id)))
+
 (defn import-resources
   ([] (import-resources "import/resources.edn"))
   ([filename]

--- a/src/juxt/site/alpha/repl.clj
+++ b/src/juxt/site/alpha/repl.clj
@@ -62,16 +62,16 @@
 
 (defn e [id]
   (postwalk
-   (fn [x] (if (and (vector? x)
-                    (#{::http/content ::http/body} (first x))
-                    (> (count (second x)) 1024))
+    (fn [x] (if (and (vector? x)
+                     (#{::http/content ::http/body} (first x))
+                     (> (count (second x)) 1024))
 
-             [(first x)
-              (cond
-                (= ::http/content (first x)) (str (subs (second x) 0 80) "…")
-                :else (format "(%d bytes)" (count (second x))))]
-             x))
-   (xt/entity (db) id)))
+              [(first x)
+               (cond
+                 (= ::http/content (first x)) (str (subs (second x) 0 80) "…")
+                 :else (format "(%d bytes)" (count (second x))))]
+              x))
+    (xt/entity (db) id)))
 
 (defn hist [id]
   (xt/entity-history (db) id :asc {:with-docs? true}))
@@ -80,44 +80,44 @@
 
 (defn put! [& ms]
   (->>
-   (xt/submit-tx
-    (xt-node)
-    (for [m ms]
-      (let [vt (:xtdb.api/valid-time m)]
-        [:xtdb.api/put (dissoc m :xtdb.api/valid-time) vt])))
-   (xt/await-tx (xt-node))))
+    (xt/submit-tx
+      (xt-node)
+      (for [m ms]
+        (let [vt (:xtdb.api/valid-time m)]
+          [:xtdb.api/put (dissoc m :xtdb.api/valid-time) vt])))
+    (xt/await-tx (xt-node))))
 
 (defn grep [re coll]
   (filter #(re-matches (re-pattern re) %) coll))
 
 (defn rm! [& ids]
   (->>
-   (xt/submit-tx
-    (xt-node)
-    (for [id ids]
-      [:xtdb.api/delete id]))
-   (xt/await-tx (xt-node))))
+    (xt/submit-tx
+      (xt-node)
+      (for [id ids]
+        [:xtdb.api/delete id]))
+    (xt/await-tx (xt-node))))
 
 (defn evict! [& ids]
   (->>
-   (xt/submit-tx
-    (xt-node)
-    (for [id ids]
-      [:xtdb.api/evict id]))
-   (xt/await-tx (xt-node))))
+    (xt/submit-tx
+      (xt-node)
+      (for [id ids]
+        [:xtdb.api/evict id]))
+    (xt/await-tx (xt-node))))
 
 (defn q [query & args]
   (apply xt/q (db) query args))
 
 (defn t [t]
   (map
-   first
-   (xt/q (db) '{:find [e] :where [[e ::site/type t]] :in [t]} t)))
+    first
+    (xt/q (db) '{:find [e] :where [[e ::site/type t]] :in [t]} t)))
 
 (defn t* [t]
   (map
-   first
-   (xt/q (db) '{:find [e] :where [[e :type t]] :in [t]} t)))
+    first
+    (xt/q (db) '{:find [e] :where [[e :type t]] :in [t]} t)))
 
 (defn types []
   (->> (q '{:find [t]
@@ -156,18 +156,18 @@
 
 (defn now-id []
   (.format
-   (.withZone
-    (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd-HHmmss")
-    (java.time.ZoneId/systemDefault))
-   (java.time.Instant/now)))
+    (.withZone
+      (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd-HHmmss")
+      (java.time.ZoneId/systemDefault))
+    (java.time.Instant/now)))
 
 ;; Start import at 00:35
 
 (defn resources-from-stream [in]
   (let [record (try
                  (edn/read
-                  {:eof :eof :readers edn-readers}
-                  in)
+                   {:eof :eof :readers edn-readers}
+                   in)
                  (catch Exception e
                    (def in in)
                    (prn (.getMessage e))))]
@@ -185,16 +185,17 @@
    (let [node (xt-node)
          in (java.io.PushbackReader. (io/reader (io/input-stream (io/file filename))))]
      (doseq [rec (resources-from-stream in)]
-       (println "Importing record" (:xt/id rec))
        (when (:xt/id rec)
-         (xt/submit-tx node [[:xtdb.api/put rec]])))
-     (xt/sync node)
-     (println "Import finished."))))
+         (if (xt/entity (xt/db node) (:xt/id rec))
+           (println "Skipping existing resource: " (:xt/id rec))
+           (do
+             (submit-and-wait-tx node [[:xtdb.api/put rec]])
+             (println "Imported resource: " (:xt/id rec)))))))))
 
 (defn validate-resource-line [s]
   (edn/read-string
-   {:eof :eof :readers edn-readers}
-   s))
+    {:eof :eof :readers edn-readers}
+    s))
 
 (defn get-zipped-output-stream []
   (let [zos (doto
@@ -210,18 +211,18 @@
     ;; Create a regex pattern which detects anything as a mapping key
     (let [pat (re-pattern (str/join "|" (map #(format "\\Q%s\\E" %) (keys mapping))))]
       (postwalk
-       (fn [s]
-         (cond-> s
-           (string? s)
-           (str/replace pat (fn [x] (get mapping x)))))
-       ent))))
+        (fn [s]
+          (cond-> s
+            (string? s)
+            (str/replace pat (fn [x] (get mapping x)))))
+        ent))))
 
 (comment
   (export-resources
-   {:pred (fn [x] (or (= (:juxt.home/type x) "Person")))
-    :filename "/home/mal/Sync/persons.edn"
-    :uri-mapping {"http://localhost:2021"
-                  "https://home.juxt.site"}}))
+    {:pred (fn [x] (or (= (:juxt.home/type x) "Person")))
+     :filename "/home/mal/Sync/persons.edn"
+     :uri-mapping {"http://localhost:2021"
+                   "https://home.juxt.site"}}))
 
 (defn export-resources
   "Export all resources to a file."
@@ -252,12 +253,12 @@
            (let [line (pr-str ent)]
              ;; Test the line can be read
              #_(try
-               (validate-resource-line line)
-               (catch Exception e
-                 (throw
-                  (ex-info
-                   (format "Serialization of entity '%s' will not be readable" (:xt/id ent))
-                   {:xt/id (:xt/id ent)} e))))
+                 (validate-resource-line line)
+                 (catch Exception e
+                   (throw
+                     (ex-info
+                       (format "Serialization of entity '%s' will not be readable" (:xt/id ent))
+                       {:xt/id (:xt/id ent)} e))))
              (.write w line)
              (.write w (System/lineSeparator))))
          (let [n (inc (first (last batch)))
@@ -280,9 +281,9 @@
 
 (defn rules []
   (sort-by
-   str
-   (map first
-        (q '{:find [(pull e [*])] :where [[e ::site/type "Rule"]]}))))
+    str
+    (map first
+         (q '{:find [(pull e [*])] :where [[e ::site/type "Rule"]]}))))
 
 (defn uuid
   ([] (str (java.util.UUID/randomUUID)))
@@ -293,10 +294,10 @@
 
 (defn req [s]
   (into
-   (sorted-map)
-   (cache/find
-    cache/requests-cache
-    (re-pattern (str "/_site/requests/" s)))))
+    (sorted-map)
+    (cache/find
+      cache/requests-cache
+      (re-pattern (str "/_site/requests/" s)))))
 
 (defn recent
   ([] (recent 5))
@@ -335,12 +336,12 @@
   ([{::site/keys [base-uri]}]
    (map first
         (xt/q (db) '{:find [user]
-                    :where [[user ::site/type "User"]
-                            [mapping ::site/type "UserRoleMapping"]
-                            [mapping ::pass/assignee user]
-                            [mapping ::pass/role superuser]]
-                    :in [superuser]}
-             (str base-uri "/_site/roles/superuser")))))
+                     :where [[user ::site/type "User"]
+                             [mapping ::site/type "UserRoleMapping"]
+                             [mapping ::pass/assignee user]
+                             [mapping ::pass/role superuser]]
+                     :in [superuser]}
+              (str base-uri "/_site/roles/superuser")))))
 
 (defn steps
   ([] (steps (config)))
@@ -350,11 +351,11 @@
          db (xt/db (xt-node))]
      [;; Awaiting a fix to https://github.com/juxt/xtdb/issues/1480
       #_{:complete? (and
-                   (xt/entity db (str base-uri "/_site/tx_fns/put_if_match_wildcard"))
-                   (xt/entity db (str base-uri "/_site/tx_fns/put_if_match_etags")))
-       :happy-message "Site transaction functions installed."
-       :sad-message "Site transaction functions not installed. "
-       :fix "Enter (put-site-txfns!) to fix this."}
+                      (xt/entity db (str base-uri "/_site/tx_fns/put_if_match_wildcard"))
+                      (xt/entity db (str base-uri "/_site/tx_fns/put_if_match_etags")))
+         :happy-message "Site transaction functions installed."
+         :sad-message "Site transaction functions not installed. "
+         :fix "Enter (put-site-txfns!) to fix this."}
 
       {:complete? (xt/entity db (str base-uri "/_site/apis/site/openapi.json"))
        :happy-message "Site API resources installed."
@@ -384,9 +385,9 @@
      (if complete?
        (println "[✔] " (ansi/green happy-message))
        (println
-        "[ ] "
-        (ansi/red sad-message)
-        (ansi/yellow fix))))
+         "[ ] "
+         (ansi/red sad-message)
+         (ansi/yellow fix))))
    (println)
    (if (every? :complete? steps) :ok :incomplete)))
 
@@ -426,11 +427,11 @@
    (let [config (config)
          xt-node (xt-node)]
      (init/put-superuser!
-      xt-node
-      {:username username
-       :fullname fullname
-       :password password}
-      config)
+       xt-node
+       {:username username
+        :fullname fullname
+        :password password}
+       config)
      (status (steps config)))))
 
 (defn update-site-graphql
@@ -463,12 +464,12 @@
 (defn reset-password! [username password]
   (let [user (str (::site/base-uri (config))  "/_site/users/" username)]
     (put!
-     {:xt/id (str user "/password")
-      ::site/type "Password"
-      ::http/methods #{:post}
-      ::pass/user user
-      ::pass/password-hash (password/encrypt password)
-      ::pass/classification "RESTRICTED"})))
+      {:xt/id (str user "/password")
+       ::site/type "Password"
+       ::http/methods #{:post}
+       ::pass/user user
+       ::pass/password-hash (password/encrypt password)
+       ::pass/classification "RESTRICTED"})))
 
 (defn user [username]
   (e (format "%s/_site/users/%s" (::site/base-uri (config)) username)))

--- a/test/juxt/site/graphql_test.clj
+++ b/test/juxt/site/graphql_test.clj
@@ -31,21 +31,21 @@
 (defn graphql []
   (init/put-site-api! *xt-node* {::site/base-uri "https://example.org"})
   (submit-and-await!
-   [[:xtdb.api/put access-all-areas]
+    [[:xtdb.api/put access-all-areas]
 
-    [:xtdb.api/put
-     {:xt/id "https://example.org/_site/users/mal"
-      :juxt.site.alpha/type "User"
-      :juxt.pass.alpha/username "mal"
-      :email "mal@juxt.pro"
-      :name "Malcolm Sparks"}]
+     [:xtdb.api/put
+      {:xt/id "https://example.org/_site/users/mal"
+       :juxt.site.alpha/type "User"
+       :juxt.pass.alpha/username "mal"
+       :email "mal@juxt.pro"
+       :name "Malcolm Sparks"}]
 
-    [:xtdb.api/put
-     {:xt/id "https://example.org/_site/users/alx"
-      :juxt.site.alpha/type "User"
-      :juxt.pass.alpha/username "alx"
-      :email "alx@juxt.pro"
-      :name "Alex Davis"}]])
+     [:xtdb.api/put
+      {:xt/id "https://example.org/_site/users/alx"
+       :juxt.site.alpha/type "User"
+       :juxt.pass.alpha/username "alx"
+       :email "alx@juxt.pro"
+       :name "Alex Davis"}]])
 
   ;; GraphQL query (direct, for EDN)
   (let [query "{ allUsers { id } }"
@@ -54,11 +54,11 @@
         bytes (.getBytes json)
 
         r (*handler*
-           {:ring.request/method :post
-            :ring.request/path "/_site/graphql"
-            :ring.request/headers {"content-length" (str (count bytes))
-                                   "content-type" "application/json"}
-            :ring.request/body (ByteArrayInputStream. bytes)})]
+            {:ring.request/method :post
+             :ring.request/path "/_site/graphql"
+             :ring.request/headers {"content-length" (str (count bytes))
+                                    "content-type" "application/json"}
+             :ring.request/body (ByteArrayInputStream. bytes)})]
 
     (is (= 200 (:ring.response/status r)))
     (is (= {"data"
@@ -70,67 +70,67 @@
   (graphql))
 
 #_((t/join-fixtures [with-xt with-handler])
- (fn []
-   (submit-and-await!
-    [[:xtdb.api/put
-      {:xt/id "https://example.org/_site/users/mal",
-       :juxt.site.alpha/type "User",
-       :juxt.pass.alpha/username "mal",
-       :email "mal@juxt.pro",
-       :name "Malcolm Sparks"}]
+   (fn []
+     (submit-and-await!
+       [[:xtdb.api/put
+         {:xt/id "https://example.org/_site/users/mal",
+          :juxt.site.alpha/type "User",
+          :juxt.pass.alpha/username "mal",
+          :email "mal@juxt.pro",
+          :name "Malcolm Sparks"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/users/alx",
-       :juxt.site.alpha/type "User",
-       :juxt.pass.alpha/username "alx",
-       :email "alx@juxt.pro",
-       :name "Alex Davis"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/users/alx",
+          :juxt.site.alpha/type "User",
+          :juxt.pass.alpha/username "alx",
+          :email "alx@juxt.pro",
+          :name "Alex Davis"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/users/joa",
-       :juxt.site.alpha/type "User",
-       :juxt.pass.alpha/username "joa",
-       :email "joa@juxt.pro",
-       :name "Johanna Antonelli"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/users/joa",
+          :juxt.site.alpha/type "User",
+          :juxt.pass.alpha/username "joa",
+          :email "joa@juxt.pro",
+          :name "Johanna Antonelli"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/roles/superuser",
-       :juxt.site.alpha/type "Role",
-       :name "superuser",
-       :description "Superuser"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/roles/superuser",
+          :juxt.site.alpha/type "Role",
+          :name "superuser",
+          :description "Superuser"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/roles/developer",
-       :juxt.site.alpha/type "Role",
-       :name "developer",
-       :description "Developer"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/roles/developer",
+          :juxt.site.alpha/type "Role",
+          :name "developer",
+          :description "Developer"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/roles/superuser/users/mal",
-       ::site/type "UserRoleMapping",
-       ::pass/assignee "https://example.org/_site/users/mal",
-       ::pass/role "https://example.org/_site/roles/superuser"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/roles/superuser/users/mal",
+          ::site/type "UserRoleMapping",
+          ::pass/assignee "https://example.org/_site/users/mal",
+          ::pass/role "https://example.org/_site/roles/superuser"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/roles/developer/users/mal",
-       ::site/type "UserRoleMapping",
-       ::pass/assignee "https://example.org/_site/users/mal",
-       ::pass/role "https://example.org/_site/roles/developer"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/roles/developer/users/mal",
+          ::site/type "UserRoleMapping",
+          ::pass/assignee "https://example.org/_site/users/mal",
+          ::pass/role "https://example.org/_site/roles/developer"}]
 
-     [:xtdb.api/put
-      {:xt/id "https://example.org/_site/roles/superuser/users/joa",
-       ::site/type "UserRoleMapping",
-       ::pass/assignee "https://example.org/_site/users/joa",
-       ::pass/role "https://example.org/_site/roles/developer"}]
+        [:xtdb.api/put
+         {:xt/id "https://example.org/_site/roles/superuser/users/joa",
+          ::site/type "UserRoleMapping",
+          ::pass/assignee "https://example.org/_site/users/joa",
+          ::pass/role "https://example.org/_site/roles/developer"}]
 
-     ])
+        ])
 
-   (let [schema-str (slurp (io/resource "juxt/site/alpha/site-schema.graphql"))
-         schema (schema/compile-schema (parser/parse schema-str))
-         query "{ allUsers { id  name email roles { name } } }"
-         document (document/compile-document (parser/parse query) schema)]
+     (let [schema-str (slurp (io/resource "juxt/site/alpha/site-schema.graphql"))
+           schema (schema/compile-schema (parser/parse schema-str))
+           query "{ allUsers { id  name email roles { name } } }"
+           document (document/compile-document (parser/parse query) schema)]
 
-     (graphql/query schema document nil {} {::site/db (x/db *xt-node*)}))))
+       (graphql/query schema document nil {} {::site/db (x/db *xt-node*)}))))
 
 
 (defn add-body [m s ct]
@@ -144,54 +144,54 @@
   (let [query "query { persons { name }}"]
 
     (submit-and-await!
-     [[:xtdb.api/put access-all-areas]
+      [[:xtdb.api/put access-all-areas]
 
-      [:xtdb.api/put
-       {:xt/id "https://example.org/alice"
-        :type "Person"
-        :name "Alice"}]
+       [:xtdb.api/put
+        {:xt/id "https://example.org/alice"
+         :type "Person"
+         :name "Alice"}]
 
-      [:xtdb.api/put
-       {:xt/id "https://example.org/bob"
-        :type "Person"
-        :name "Bob"}]
+       [:xtdb.api/put
+        {:xt/id "https://example.org/bob"
+         :type "Person"
+         :name "Bob"}]
 
-      [:xtdb.api/put
-       {:xt/id "https://example.org/graphql"
-        :doc "A GraphQL endpoint"
-        :juxt.http.alpha/methods #{:post :put :options}
-        :juxt.http.alpha/acceptable "application/graphql"
-        :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
-        :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]
+       [:xtdb.api/put
+        {:xt/id "https://example.org/graphql"
+         :doc "A GraphQL endpoint"
+         :juxt.http.alpha/methods #{:post :put :options}
+         :juxt.http.alpha/acceptable "application/graphql"
+         :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
+         :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]
 
-      [:xtdb.api/put
-       {:xt/id "https://example.org/get-persons"
-        :doc "A GraphQL stored query"
-        :juxt.http.alpha/methods #{:put :post}
-        :juxt.http.alpha/acceptable #{"application/graphql" "application/json"}
-        :juxt.site.alpha/graphql-schema "https://example.org/graphql"
-        :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/stored-document-put-handler
-        :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/stored-document-post-handler}]
+       [:xtdb.api/put
+        {:xt/id "https://example.org/get-persons"
+         :doc "A GraphQL stored query"
+         :juxt.http.alpha/methods #{:put :post}
+         :juxt.http.alpha/acceptable #{"application/graphql" "application/json"}
+         :juxt.site.alpha/graphql-schema "https://example.org/graphql"
+         :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/stored-document-put-handler
+         :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/stored-document-post-handler}]
 
-      ;; Install variants to have CSV output
-      ])
+       ;; Install variants to have CSV output
+       ])
 
     ;; Install a GraphQL schema at /graphql
     (let [schema "
 type Query { persons: [Person] @site(q: { find: [e] where: [[e {keyword: \"type\"} \"Person\"]]})}
 type Person { name: String @site(a: \"name\")}"
           response (*handler*
-                    (-> {:ring.request/method :put
-                         :ring.request/path "/graphql"}
-                        (add-body schema "application/graphql")))]
+                     (-> {:ring.request/method :put
+                          :ring.request/path "/graphql"}
+                         (add-body schema "application/graphql")))]
       (is (= 204 (:ring.response/status response))))
 
     ;; POST a query to that schema
     (let [response
           (*handler*
-           (-> {:ring.request/method :post
-                :ring.request/path "/graphql"}
-               (add-body query "application/graphql")))
+            (-> {:ring.request/method :post
+                 :ring.request/path "/graphql"}
+                (add-body query "application/graphql")))
           body (json/read-value (:ring.response/body response))]
 
       (is (= 200 (:ring.response/status response)))
@@ -199,19 +199,19 @@ type Person { name: String @site(a: \"name\")}"
 
     ;; PUT a stored query
     (*handler*
-     (-> {:ring.request/method :put
-          :ring.request/path "/get-persons"}
-         (add-body query "application/graphql")))
+      (-> {:ring.request/method :put
+           :ring.request/path "/get-persons"}
+          (add-body query "application/graphql")))
 
     ;; POST to a stored query
     #_(*handler*
-       (-> {:ring.request/method :post
-            :ring.request/path "/get-persons"}
-           (add-body (json/write-value-as-string {}) "application/json")))))
+        (-> {:ring.request/method :post
+             :ring.request/path "/get-persons"}
+            (add-body (json/write-value-as-string {}) "application/json")))))
 
 #_((t/join-fixtures [with-xt with-handler])
- stored-query
- )
+   stored-query
+   )
 
 (deftest stored-query-test
   (stored-query))
@@ -239,29 +239,29 @@ type Mutation {
         query "mutation { addPerson(id: \"https://example.org/persons/mal\" name: \"Malcolm Sparks\") { id name }}"]
 
     (submit-and-await!
-     [[:xtdb.api/put access-all-areas]
+      [[:xtdb.api/put access-all-areas]
 
-      [:xtdb.api/put
-       {:xt/id "https://example.org/graphql"
-        :doc "A GraphQL endpoint"
-        :juxt.http.alpha/methods #{:post :put :options}
-        :juxt.http.alpha/acceptable "application/graphql"
-        :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
-        :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]])
+       [:xtdb.api/put
+        {:xt/id "https://example.org/graphql"
+         :doc "A GraphQL endpoint"
+         :juxt.http.alpha/methods #{:post :put :options}
+         :juxt.http.alpha/acceptable "application/graphql"
+         :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
+         :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]])
 
     ;; Install a GraphQL schema at /graphql
     (let [response (*handler*
-                    (-> {:ring.request/method :put
-                         :ring.request/path "/graphql"}
-                        (add-body schema "application/graphql")))]
+                     (-> {:ring.request/method :put
+                          :ring.request/path "/graphql"}
+                         (add-body schema "application/graphql")))]
       (is (= 204 (:ring.response/status response))))
 
     ;; POST a mutation to that endpoint
     (let [response
           (*handler*
-           (-> {:ring.request/method :post
-                :ring.request/path "/graphql"}
-               (add-body query "application/graphql")))]
+            (-> {:ring.request/method :post
+                 :ring.request/path "/graphql"}
+                (add-body query "application/graphql")))]
 
       (when (= (get-in response [:ring.response/status]) 500)
         (throw (ex-info "Unexpected error" {:response response})))
@@ -281,7 +281,7 @@ type Mutation {
                 :juxt.site/type "Person"
                 :name "Malcolm Sparks"}
                (-> (xt/entity db "https://example.org/persons/mal")
-                   (dissoc :_siteCreatedAt)))))
+                   (select-keys [:xt/id :juxt.site/type :name])))))
 
       (let [body (json/read-value (:ring.response/body response))]
         (is (= {"data"
@@ -290,13 +290,11 @@ type Mutation {
                   "name" "Malcolm Sparks"}}}
                body))
         ;;body
-        ))
-
-    ))
+        ))))
 
 #_((t/join-fixtures [with-xt with-handler])
    mutation
- )
+   )
 
 (deftest mutation-test
   (mutation))
@@ -305,8 +303,8 @@ type Mutation {
 #_(parser/parse "mutation { addPerson { name }}")
 
 #_(schema/compile-schema
- (parser/parse
-  "
+    (parser/parse
+      "
 schema { query: Query mutation: Mutation }
 type Query { person: Person }
 enum WorkerStatus { EMPLOYEE CONTIGENT }
@@ -322,4 +320,4 @@ type Mutation {
   addHoliday(person: ID beginning: Date! ending: Date! description: String): Holiday
 }
 "
-  ))
+      ))


### PR DESCRIPTION
Best to view diffs by commit since one commit is purely indentation (we should probably do something about not having a ci step to enforce indentation rules)

- updates xt to 1.21
- adds the ability to use {{subject}} in the q directive

NOTE: you will need to delete xt indexes before you start the process again, i.e `rm -r db/idxs`