### PR TITLE
Add diehard resilience to OpenID connect auth and AWS Cognito support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -59,6 +59,10 @@
         ;; Required by OpenID Connect for http and retry resilience
         hato/hato {:mvn/version "0.8.2"}
         diehard/diehard {:mvn/version "0.11.3"}
+        ; Used by openidconnect for the URIBuilder
+        org.apache.httpcomponents/httpclient {:mvn/version "4.5.9"}
+        ; Used by openidconnect for determining TLD of issuer
+        com.google.guava/guava {:mvn/version "30.0-jre"}
 
         ;; Required for OAuth2, not necessarily only for Auth0 since it
         ;; implements the relevant standards so any OAuth2 provided should work.

--- a/deps.edn
+++ b/deps.edn
@@ -56,8 +56,9 @@
         ;; Selmer templating
         selmer/selmer {:mvn/version "1.12.40"}
 
-        ;; Required by a few components, including Slack and OpenID Connect
-        java-http-clj/java-http-clj {:mvn/version "0.4.3"}
+        ;; Required by OpenID Connect for http and retry resilience
+        hato/hato {:mvn/version "0.8.2"}
+        diehard/diehard {:mvn/version "0.11.3"}
 
         ;; Required for OAuth2, not necessarily only for Auth0 since it
         ;; implements the relevant standards so any OAuth2 provided should work.

--- a/src/juxt/pass/alpha/openid_connect.clj
+++ b/src/juxt/pass/alpha/openid_connect.clj
@@ -11,7 +11,8 @@
    [clojure.string :as str]
    [clojure.tools.logging :as log]
    [crux.api :as crux]
-   [java-http-clj.core :as hc]
+   [diehard.core :as dh]
+   [hato.client :as hc]
    [jsonista.core :as json]
 
    [juxt.pass.alpha.session :as session]
@@ -44,7 +45,6 @@
 
         query-params (some-> req :ring.request/query (codec/form-decode "US-ASCII"))
         return-to (get query-params "return-to")
-        fail-to (get query-params "fail-to")
 
         _ (when-not oauth-client-id
             (return req 500 "No oauth client id found" {}))
@@ -68,9 +68,8 @@
         _ (put-session!
            session-token-id!
            (cond-> {::pass/state state ::pass/nonce nonce}
-             return-to (assoc ::pass/return-to return-to)
-             fail-to (assoc ::pass/fail-to fail-to))
-           (.plusSeconds (.toInstant start-date) expires-in))
+             return-to (assoc ::pass/return-to return-to))
+             (.plusSeconds (.toInstant start-date) expires-in))
 
         query-string
         (codec/form-encode
@@ -186,10 +185,16 @@
       (do
         (log/infof "Fetching JWKS from %s" uri)
         (let [{:keys [status body]}
-              (hc/send
-               {:method :get
-                :uri uri
-                :headers {"Accept" "application/json"}})
+              (dh/with-retry
+                {:retry-on Exception
+                 :max-retries 2
+                 :delay-ms 100
+                 :on-failed-attempt
+                 (fn [_ e] (log/warnf "OAuth JWKS call failed due to: %s" e))
+                 :on-failure
+                 (fn [_ e] (log/errorf "OAuth JWKS call failed 3 times: %s" e))}
+                (hc/get uri {:accept :json}))
+
               _ (when-not (= status 200)
                   (return req 500 "Failed to fetch JWKS from %s" {} uri))
               result
@@ -205,8 +210,10 @@
         (map first
              (crux/q db '{:find [i]
                           :where [[i :juxt.site.alpha/type "User"]
-                                  [i :juxt.pass.jwt/iss iss]
-                                  [i :juxt.pass.jwt/sub sub]]
+                                  [oc :juxt.site.alpha/type "OAuthCredentials"]
+                                  [oc :juxt.pass.alpha/user i]
+                                  [oc :juxt.pass.jwt/iss iss]
+                                  [oc :juxt.pass.jwt/sub sub]]
                           :in [iss sub]}
                      (get id-token-claims "iss")
                      (get id-token-claims "sub")))]
@@ -226,103 +233,109 @@
     ::pass/keys [session session-token-id!]
     :ring.request/keys [query]
     :as req}]
+  (try
+    (when-not session-token-id!
+      (return req 500 "No session token id" {}))
 
-  (when-not session-token-id!
-    (return req 500 "No session token id" {}))
+    (when-not session
+      (return req 500 "No session found" {}))
 
-  (when-not session
-    (return req 500 "No session found" {}))
+    ;; Exchange code for JWT
+    (let [{::pass/keys [oauth-client]} resource
+          {::pass/keys [oauth-client-id oauth-client-secret redirect-uri openid-issuer-id]}
+          (crux/entity db oauth-client)
 
-  ;; Exchange code for JWT
-  (let [{::pass/keys [oauth-client]} resource
-        {::pass/keys [oauth-client-id oauth-client-secret redirect-uri openid-issuer-id]}
-        (crux/entity db oauth-client)
+          openid-configuration (some-> openid-issuer-id (lookup db) ::pass/openid-configuration)
 
-        openid-configuration (some-> openid-issuer-id (lookup db) ::pass/openid-configuration)
+          _ (when-not openid-configuration
+              (return req 500 "No openid configuration found" {:openid-issuer-id openid-issuer-id}))
 
-        _ (when-not openid-configuration
-            (return req 500 "No openid configuration found" {:openid-issuer-id openid-issuer-id}))
+          token-endpoint (get openid-configuration "token_endpoint")
 
-        token-endpoint (get openid-configuration "token_endpoint")
+          query-params (some-> query (codec/form-decode "US-ASCII"))
 
-        query-params (some-> query (codec/form-decode "US-ASCII"))
+          state-received (when (map? query-params) (get query-params "state"))
+          state-sent (::pass/state session)
 
-        state-received (when (map? query-params) (get query-params "state"))
-        state-sent (::pass/state session)
+          _ (when-not state-sent
+              (return req 500 "Expected to find state in session" {}))
 
-        _ (when-not state-sent
-            (return req 500 "Expected to find state in session" {}))
+          _ (when-not (= state-sent state-received)
+              ;; This could be a CSRF attack, we should log an alert
+              (return req 500 "State mismatch" {:state-received state-received
+                                                :session session}))
 
-        _ (when-not (= state-sent state-received)
-            ;; This could be a CSRF attack, we should log an alert
-            (return req 500 "State mismatch" {:state-received state-received
-                                              :session session}))
+          code (when (map? query-params) (get query-params "code"))
 
-        code (when (map? query-params) (get query-params "code"))
+          _ (when-not code
+              (return req 500 "No code returned from provider" {}))
 
-        _ (when-not code
-            (return req 500 "No code returned from provider" {}))
+          _ (when-not oauth-client-id
+              (return req 500 "The required OAuth client id was not found" {}))
 
-        _ (when-not oauth-client-id
-            (return req 500 "The required OAuth client id was not found" {}))
+          _ (when-not oauth-client-secret
+              (return req 500 "The required OAuth client secret was not found" {}))
 
-        _ (when-not oauth-client-secret
-            (return req 500 "The required OAuth client secret was not found" {}))
+          jwks-uri (get openid-configuration "jwks_uri")
+          _ (when-not jwks-uri
+              (return req 500 "No JWKS URI in configuration" {}))
 
-        jwks-uri (get openid-configuration "jwks_uri")
-        _ (when-not jwks-uri
-            (return req 500 "No JWKS URI in configuration" {}))
+          jwks (cached-jwks-fetch req jwks-uri (* 60 60 24))
+          _ (when-not jwks
+              (return req 500 "No JWKS found" {}))
 
-        jwks (cached-jwks-fetch req jwks-uri (* 60 60 24))
-        _ (when-not jwks
-            (return req 500 "No JWKS found" {}))
+          {:keys [status headers body] :as response}
+          (dh/with-retry
+            {:retry-on Exception
+             :max-retries 2
+             :delay-ms 100
+             :on-failed-attempt
+             (fn [_ e] (log/warnf "OAuth token call failed due to: %s" e))
+             :on-failure
+             (fn [_ e] (log/errorf "OAuth token call failed 3 times: %s" e))}
+            (hc/post
+             token-endpoint
+             {:form-params
+              {"grant_type" "authorization_code"
+               "client_id" oauth-client-id
+               "client_secret" oauth-client-secret
+               "code" code
+               "redirect_uri" redirect-uri}
+              :accept :json}))
 
-        token-request
-        {:method :post
-         :uri token-endpoint
-         :headers {"Content-Type" "application/json" #_"application/x-www-form-urlencoded"
-                   "Accept" "application/json"}
-         :body (json/write-value-as-string
-                {"grant_type" "authorization_code"
-                 "client_id" oauth-client-id
-                 "client_secret" oauth-client-secret
-                 "code" code
-                 "redirect_uri" redirect-uri})}
+          _ (when-not (= status 200)
+              (return req 500 "Token request failed with response: " response))
 
-        {:keys [status headers body] :as response}
-        (hc/send
-         token-request
-         {:as :byte-array})
+          json-body (json/read-value body)
 
-        json-body (json/read-value body)
+          id-token (decode-id-token req (get json-body "id_token") jwks openid-configuration oauth-client-id)
+          _ (def id-token id-token)
 
-        id-token (decode-id-token req (get json-body "id_token") jwks openid-configuration oauth-client-id)
+          original-nonce (::pass/nonce session)
+          claimed-nonce (get-in id-token [:claims "nonce"])
 
-        original-nonce (::pass/nonce session)
-        claimed-nonce (get-in id-token [:claims "nonce"])
+          _ (when-not original-nonce
+              (return req 500 "Expected to find nonce in session" {}))
 
-        _ (when-not original-nonce
-            (return req 500 "Expected to find nonce in session" {}))
+          _ (when-not (=  claimed-nonce original-nonce)
+              ;; This is possibly an attack, we should log an alert
+              (return req 500 "Nonce received does not match expected" {}))
 
-        _ (when-not (=  claimed-nonce original-nonce)
-            ;; This is possibly an attack, we should log an alert
-            (return req 500 "Nonce received does not match expected" {}))
+          ;; Does the id-token match any identities in our database?
+          matched-identity (match-identity db (:claims id-token))
+          iss-sub (pr-str (select-keys (:claims id-token) ["iss" "sub"]))]
 
-        ;; Does the id-token match any identities in our database?
-        matched-identity (match-identity db (:claims id-token))]
+      (when-not matched-identity
+        (return req 500 "No known identity match for claims %s" {} iss-sub))
 
-    ;; Put the ID_TOKEN into the session, cycle the session id and redirect to
-    ;; the redirect URI stored in the original session.
-
-    (if matched-identity
-
+      ;; If iss and sub match identity put the ID_TOKEN into the session and cycle the session id
+      ;; Always redirect to the redirect_uri stored in the session but only include code query
+      ;; parameter if matched identity was found to indicate success
+      (log/warnf "Successful login! %s matched claims %s" matched-identity iss-sub)
+      (-> req
+          (redirect 303 (get session ::pass/return-to "/"))
+          (session/escalate-session matched-identity)))
+    (catch Exception e
       (do
-        (log/warnf "Successful login! %s" (pr-str (select-keys (:claims id-token) ["iss" "sub"])))
-        (-> req
-            (redirect 303 (get session ::pass/return-to "/login-succeeded"))
-            (session/escalate-session matched-identity)))
-
-      ;; Login unsuccessful.
-      (do
-        (log/warnf "Unsuccessful login, no known identity match for claims %s" (pr-str (select-keys (:claims id-token) ["iss" "sub"])))
-        (redirect req 303 (get session ::pass/fail-to "/login-failed"))))))
+        (log/warnf "Unsuccessful login: %s" e)
+        (redirect req 303 (get session ::pass/return-to "/"))))))

--- a/src/juxt/pass/alpha/session.clj
+++ b/src/juxt/pass/alpha/session.clj
@@ -8,7 +8,9 @@
   (:require
    [juxt.pass.alpha.authentication :as authz]
    [ring.middleware.cookies :refer [cookies-request cookies-response]]
-   [clojure.tools.logging :as log]))
+   [clojure.tools.logging :as log])
+  (:import
+   (org.apache.http.client.utils URIBuilder)))
 
 (alias 'http (create-ns 'juxt.http.alpha))
 (alias 'pass (create-ns 'juxt.pass.alpha))
@@ -48,7 +50,11 @@
 
     (-> req
         (set-cookie new-session-token-id!)
-        (update-in [:ring.response/headers "location"] #(str % "?code=" new-session-token-id!)))))
+        (update-in [:ring.response/headers "location"]
+            (fn [location]
+              (-> (new URIBuilder location)
+                  (.addParameter "code" new-session-token-id!)
+                  (.toString)))))))
 
 (defn wrap-associate-session [h]
   (fn [{::site/keys [db start-date] :as req}]

--- a/src/juxt/pass/alpha/session.clj
+++ b/src/juxt/pass/alpha/session.clj
@@ -1,21 +1,23 @@
-(ns juxt.pass.alpha.session)
+(ns juxt.pass.alpha.session
 
 ;; Copyright © 2022, JUXT LTD.
 
 ;; References --
 ;; [OWASP-SM]: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
 
-(ns juxt.pass.alpha.session
   (:require
-   [juxt.pass.alpha.util :refer [make-nonce]]
    [juxt.pass.alpha.authentication :as authz]
    [ring.middleware.cookies :refer [cookies-request cookies-response]]
-   [clojure.tools.logging :as log]
-   [crux.api :as xt]))
+   [clojure.tools.logging :as log]))
 
 (alias 'http (create-ns 'juxt.http.alpha))
 (alias 'pass (create-ns 'juxt.pass.alpha))
 (alias 'site (create-ns 'juxt.site.alpha))
+
+;; The id cookie is only used during the OAuth Authorization Flow using
+;; OpenID Connect for Authentication. It is used to store the session-token-id
+;; created before calling the authorize endpoint. The session is used to prevent
+;; CSRF-attacks as it stores the random state and nonce values for comparison.
 
 (defn ->cookie [session-token-id]
   ;; TODO: In local testing (against home.test) it seems that setting
@@ -36,7 +38,7 @@
     ::pass/keys [session-token-id!] :as req} matched-identity]
   (let [session (authz/lookup-session session-token-id! start-date)
         _ (assert session)
-        new-session-token-id! (make-nonce 16)
+        new-session-token-id! (authz/access-token)
         expires-in (get resource ::pass/expires-in (* 24 3600))]
     (authz/remove-session! session-token-id!)
     (authz/put-session!

--- a/src/juxt/site/alpha/init.clj
+++ b/src/juxt/site/alpha/init.clj
@@ -52,7 +52,7 @@
 
 (defn put-superuser!
   "Create a superuser."
-  [crux-node username password fullname email {::site/keys [base-uri]}]
+  [crux-node username password fullname email {::site/keys [base-uri] :as config}]
   (let [user (str base-uri "/_site/users/" username)]
     (put!
      crux-node
@@ -67,6 +67,12 @@
       ::pass/user user
       ::pass/password-hash (password/encrypt password)
       ::pass/classification "RESTRICTED"}
+
+     {:crux.db/id (str user "/oauth-credentials")
+      ::site/type "OAuthCredentials"
+      ::pass/user user
+      :juxt.pass.jwt/iss (-> config :openid :issuer-id)
+      :juxt.pass.jwt/sub (-> config :openid :superuser-sub)}
 
      {:crux.db/id (format "%s/_site/roles/%s/users/%s" base-uri "superuser" username)
       ::site/type "UserRoleMapping"


### PR DESCRIPTION
Add retry behaviour to network calls during OpenID connect authentication. Also change call to token endpoint to use form parameters rather than a JSON body as AWS Cognito only supports form parameters.

To enable a user to login using this flow a 'OAuthCredentials' entity must be created with a `:juxt.pass.jwt/iss` and `:juxt.pass.jwt/sub` pair along with the ':juxt.pass.alpha/user' id of the user.