### PR TITLE
Fixed errors in reloading namespaces from REPL

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -4,10 +4,10 @@
   (:require
    clojure.main
    [io.aviso.ansi :as ansi]
-   [juxt.site.alpha.main :as main]
+   [juxt.site.alpha.main]
    [clojure.tools.logging :as log]
    [clojure.java.io :as io]
-   [juxt.site.alpha.repl :refer :all]
+   [juxt.site.alpha.repl]
    [integrant.core :as ig]
    [xtdb.api :as xt]))
 
@@ -34,15 +34,15 @@
   (log/info "Starting development system")
 
 
-  (alter-var-root #'main/profile (constantly :dev))
-  (let [system-config (main/system-config)
+  (alter-var-root #'juxt.site.alpha.main/profile (constantly :dev))
+  (let [system-config (juxt.site.alpha.main/system-config)
         sys (ig/init system-config)]
-    (alter-var-root #'main/system (constantly sys)))
+    (alter-var-root #'juxt.site.alpha.main/system (constantly sys)))
   (log/info "System started and ready...")
 
   (println)
   (println "Welcome to Site!")
-  (status)
+  (juxt.site.alpha.repl/status)
 
   (println (ansi/yellow "Enter (help) for help"))
 

--- a/src/juxt/apex/alpha/helpers.clj
+++ b/src/juxt/apex/alpha/helpers.clj
@@ -14,7 +14,8 @@
   (let [;; Operation can contain extra config, such as uri-templates
         operation (::apex/operation resource)
 
-        resource-state (openapi/received-body->resource-state req)
+        ; resource-state (openapi/received-body->resource-state req) ;; No such var
+        resource-state {}
 
         ;; TODO: This is just a hack to get a demo working - the method of
         ;; determining the identifier for the new resource needs to be more


### PR DESCRIPTION
This was likely related to my workflow only, but some of the requires I fixed generated "already defined" exceptions while trying to reload namespaces at the repl. There was also an apex namespace that couldn't work because it refers to non existing functions. Tests are green and site-server up and running.