### PR TITLE
Fix file watcher function

### DIFF
--- a/src/juxt/site/alpha/watcher.clj
+++ b/src/juxt/site/alpha/watcher.clj
@@ -151,7 +151,8 @@
   [config {:keys [type path]}]
   (log/info "Handling graphql file change" type path)
   (let [file (when (#{:create :modify} type) (file-contents path))
-        relativePath (absolute-path-to-relative (.toString path))]
+        relativePath (cond-> (.toString path)
+                      (.isAbsolute path) (absolute-path-to-relative))]
     (case type
       :create
       (upsert-schema config relativePath file)


### PR DESCRIPTION
File watcher was broken, every time new schema was added to the graphql schema directory, schema id was created incorrectly.

Root cause of this was that file watcher callback function expected new file path to always be absolute, but it was relative, at least on my env when I exactly followed site tutorial.

Adding check whether new file path is truly absolute and conditionally extracting relative-path only if this check is true fixes the issue.