### PR TITLE
Evict cascade and delete cascade mutation function

### DIFF
--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -502,13 +502,12 @@
                                 {:site-args site-args})))
             related-ids (map first
                              (xt/q db {:find ['e]
-                                       :where [['e cascade-key id]]}))]
-        (log/warn "deleting" (conj (for [id related-ids]
-                                     (xt-delete id))
-                                   (xt-delete id)))
-        (await-tx xt-node (conj (for [id related-ids]
-                                  (xt-delete id))
-                                (xt-delete id)))
+                                       :where [['e cascade-key id]]}))
+            delete-ids (conj (for [id related-ids]
+                               (xt-delete id))
+                             (xt-delete id))]
+        (log/warn "deleting" delete-ids)
+        (await-tx xt-node delete-ids)
         ;; TODO: Allow an argument to correspond to valid-time, via
         ;; @site(a: "xtdb.api/valid-time").
         {:xt/id id})
@@ -520,13 +519,12 @@
                                 {:site-args site-args})))
             related-ids (map first
                              (xt/q db {:find ['e]
-                                       :where [['e cascade-key id]]}))]
-        (log/warn "evicting" (conj (for [id related-ids]
-                                     (xt-evict id))
-                                   (xt-evict id)))
-        (await-tx xt-node (conj (for [id related-ids]
-                                  (xt-evict id))
-                                (xt-evict id)))
+                                       :where [['e cascade-key id]]}))
+            evict-ids (conj (for [id related-ids]
+                              (xt-evict id))
+                            (xt-evict id))]
+        (log/warn "evicting" evict-ids)
+        (await-tx xt-node evict-ids)
         ;; TODO: Allow an argument to correspond to valid-time, via
         ;; @site(a: "xtdb.api/valid-time").
         {:xt/id id})

--- a/src/juxt/site/alpha/graphql.clj
+++ b/src/juxt/site/alpha/graphql.clj
@@ -334,6 +334,10 @@
   [id]
   [:xtdb.api/delete id])
 
+(defn xt-evict
+  [id]
+  [:xtdb.api/evict id])
+
 (defn xt-put
   [object valid-from]
   (and (nil? (:xt/id object))
@@ -476,7 +480,7 @@
 
 
 (defn perform-mutation!
-  [{:keys [argument-values site-args xt-node lookup-entity field-kind pass/subject] :as opts}]
+  [{:keys [argument-values site-args xt-node db lookup-entity field-kind pass/subject] :as opts}]
   (let [action (or (get site-args "mutation") "put")
         validate-id! (fn [args]
                        (let [id (get args "id")]
@@ -490,7 +494,25 @@
         ;; TODO: Allow an argument to correspond to valid-time, via
         ;; @site(a: "xtdb.api/valid-time").
         (lookup-entity id))
-      "put"
+      "evict-cascade"
+      (let [id (validate-id! argument-values)
+            cascade-key (keyword (get site-args "cascadeKey"))
+            _ (when-not cascade-key
+                (throw (ex-info "evict-cascade requires a 'cascadeKey' site directive"
+                                {:site-args site-args})))
+            related-ids (map first
+                             (xt/q db {:find ['e]
+                                       :where [['e cascade-key id]]}))]
+        (log/warn "evicting" (conj (for [id related-ids]
+                                     (xt-evict id))
+                                   (xt-evict id)))
+        (await-tx xt-node (conj (for [id related-ids]
+                                  (xt-evict id))
+                                (xt-evict id)))
+        ;; TODO: Allow an argument to correspond to valid-time, via
+        ;; @site(a: "xtdb.api/valid-time").
+        {:xt/id id})
+        "put"
       (if-let [validation-report (seq (invalid-arguments? opts))]
         (throw (Exception. (pr-str validation-report)))
         (if bulk-mutation

--- a/test/juxt/site/graphql_test.clj
+++ b/test/juxt/site/graphql_test.clj
@@ -472,13 +472,13 @@ type Mutation {
       :juxt.http.alpha/acceptable "application/graphql"
       :juxt.site.alpha/put-fn 'juxt.site.alpha.graphql/put-handler
       :juxt.site.alpha/post-fn 'juxt.site.alpha.graphql/post-handler}]
-    
+
 
     [:xtdb.api/put
      {:xt/id "https://example.org/persons/ts1"
       :type "Person"
       :name "Testuser 1"}]
-    
+
     [:xtdb.api/put
      {:xt/id "https://example.org/persons/ts2"
       :type "Person"
@@ -524,7 +524,7 @@ mutation {
              mutation: Mutation
            }
            type Query {
-                 persons: [Person]!
+                 persons: [Person] @site(q: { find: [e] where: [[e {keyword: \"type\"} \"Person\"]]})
                  person( id: ID! ): Person
            }
            type Mutation {
@@ -544,14 +544,14 @@ mutation {
                  name: String @site(a: \"name\")
                  owner: Person @site(ref: \"ownerId\")
            }"]
-    
+
     (is (= 204 (:ring.response/status (put-schema schema)))))
 
   ;; POST a query to that schema
-  (comment (let [response (post-mutation "{ persons { id name } }")
-                 body (json/read-value (:ring.response/body response))]
-
-             (is (= 200 (:ring.response/status response)))))
+  (let [response (post-mutation "{ persons { id name } }")
+        body (json/read-value (:ring.response/body response))]
+             (is (= 200 (:ring.response/status response)))
+             (is (= 2 (-> body (get-in ["data" "persons"]) count))))
 
   ;; Testing that db contains all data
 


### PR DESCRIPTION
Added evict-cascade mutation functions. 

Evict-cascade mutation evicts entity and all linked entities linked by 'casadeKey' (cascadeKey mutation attribute is required)

Delete-cascade mutation deletes entity and all linked entities linked by 'casadeKey' (cascadeKey mutation attribute is required)

The usage of evict-cascade and delete-cascade mutations is also demonstrated in tests. 