### PR TITLE
Oauth update user and associated roles

### DIFF
--- a/bin/site-server-bootstrap
+++ b/bin/site-server-bootstrap
@@ -21,4 +21,5 @@ clojure -J-Djava.awt.headless=true \
 				       \"$SITE_SUPERUSER_EMAIL\") \
                   (repl/put-auth-resources!) \
                   (repl/allow-public-access-to-public-resources!) \
+                  (repl/allow-authenticated-users-access-to-user-info!) \
                   @main-thread))"

--- a/src/juxt/site/alpha/init.clj
+++ b/src/juxt/site/alpha/init.clj
@@ -92,6 +92,21 @@
                     [resource ::pass/classification "PUBLIC"]]
     ::pass/effect ::pass/allow}))
 
+(defn allow-authenticated-users-access-to-user-info!
+  "Authenticated users should be able to access their own user details"
+  [crux-node {::site/keys [base-uri]}]
+  (put!
+   crux-node
+   {:crux.db/id (str base-uri "/_site/rules/any-authenticated-allow-user-info")
+    ::site/type "Rule"
+    ::site/description "Allow authenticated users to get their user details"
+    ::pass/target '[[subject ::pass/user user]
+                    [user ::site/type "User"]
+                    [request :ring.request/method #{:get :options}]
+                    [request :ring.request/path "/_site/user"]]
+    ::pass/effect ::pass/allow
+    ::http/max-content-length (Math/pow 2 40)}))
+
 (defn restict-access-to-restricted-resources!
   "Resources classified as RESTRICTED should never be accessed, unless another
   policy explicitly authorizes access."

--- a/src/juxt/site/alpha/openapi.edn
+++ b/src/juxt/site/alpha/openapi.edn
@@ -26,18 +26,15 @@
     {200
      {:juxt.site.alpha/query
       #juxt.site.alpha/as-str
-      {:find [id username name email (distinct role) auth-scheme]
-       :strs [id username name email roles auth-scheme]
-       :where [[:subject :juxt.pass.alpha/user user]
-               [:subject :juxt.pass.alpha/auth-scheme auth-scheme]
-               [user :crux.db/id id]
-               [user :juxt.pass.alpha/username username]
-               [user :name name]
-               [user :email email]
-               [mapping :juxt.site.alpha/type "UserRoleMapping"]
-               [mapping :juxt.pass.alpha/assignee user]
-               [mapping :juxt.pass.alpha/role role]]
+      {:find [(pull user [(:juxt.pass.alpha/username {:as :username})
+                           :name
+                           :email
+                           {(:juxt.pass.alpha/_assignee {:as :roles})
+                            [(:juxt.pass.alpha/role {:as :id})]}])]
+       :strs [user]
+       :where [[:subject :juxt.pass.alpha/user user]]
        :limit 1}
+      :juxt.site.alpha/extract-entry "user"
       :juxt.site.alpha/singular-result? true
 
       :content

--- a/src/juxt/site/alpha/repl.clj
+++ b/src/juxt/site/alpha/repl.clj
@@ -277,6 +277,11 @@
         crux-node (crux-node)]
     (init/allow-public-access-to-public-resources! crux-node config)))
 
+(defn allow-authenticated-users-access-to-user-info! []
+  (let [config (config)
+        crux-node (crux-node)]
+    (init/allow-authenticated-users-access-to-user-info! crux-node config)))
+
 (defn put-site-txfns! []
   (let [config (config)
         crux-node (crux-node)]

--- a/test/juxt/pass/openid_connect_test.clj
+++ b/test/juxt/pass/openid_connect_test.clj
@@ -1,0 +1,373 @@
+;; Copyright © 2021, JUXT LTD.
+
+(ns juxt.pass.openid-connect-test
+  (:require
+   [clojure.test :as t :refer [deftest is testing]]
+   [crux.api :as crux]
+   [hato.client :as hc]
+   [juxt.pass.alpha.authentication :as auth]
+   [juxt.pass.alpha.util :as util]
+   [juxt.pass.alpha.openid-connect :as openid]
+   [juxt.pass.openid-connect-test-utils :as tutils]
+   [juxt.site.alpha.init :as site-init]
+   [juxt.test.util :refer [*crux-node* *handler* *sessions*
+                           with-crux with-handler with-sessions]
+    :as test-util])
+  (:import
+   (com.auth0.jwt JWT)
+   (java.time Instant)))
+
+(alias 'pass (create-ns 'juxt.pass.alpha))
+(alias 'site (create-ns 'juxt.site.alpha))
+
+(t/use-fixtures :each with-crux with-handler with-sessions
+  test-util/reset-sessions!
+  test-util/allow-access-to-public-resources!)
+
+(deftest openid-auth0-login-redirect-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "auth0")]
+    (site-init/install-openid-provider! *crux-node* "https://dev-14bkigf7.us.auth0.com/"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "auth0"
+             :issuer-id "https://dev-14bkigf7.us.auth0.com/"
+             :client-id "clientidihgfedcba123456789"
+             :client-secret "clientsecretihgfedcba123456789"}})
+
+  (testing
+   (let [resp (with-redefs
+               [util/make-nonce tutils/mock-make-nonce]
+                (*handler*
+                 {:ring.request/method :get
+                  :ring.request/path "/_site/openid/auth0/login"}))]
+
+     (is (contains? @*sessions* "cccccccccccccccc"))
+     (is (= "aaaaaaaa" (get-in @*sessions* ["cccccccccccccccc" ::pass/state])))
+     (is (= "bbbbbbbbbbbb" (get-in @*sessions* ["cccccccccccccccc" ::pass/nonce])))
+     (is (nil? (get-in @*sessions* ["cccccccccccccccc" ::pass/return-to])))
+
+     (is (= 303 (:ring.response/status resp)))
+     (is (= "https://dev-14bkigf7.us.auth0.com/authorize?response_type=code&scope=openid&client_id=clientidihgfedcba123456789&redirect_uri=https%3A%2F%2Fexample.org%2F_site%2Fopenid%2Fauth0%2Fcallback&state=aaaaaaaa&nonce=bbbbbbbbbbbb&prompt=login"
+            (get-in resp [:ring.response/headers "location"]))))))
+
+(deftest openid-aws-cognito-login-redirect-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "clientid123456789abcdefghi"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (testing
+   (let [resp (with-redefs
+               [util/make-nonce tutils/mock-make-nonce]
+                (*handler*
+                 {:ring.request/method :get
+                  :ring.request/path "/_site/openid/aws-cognito/login"}))]
+
+     (is (contains? @*sessions* "cccccccccccccccc"))
+     (is (= "aaaaaaaa" (get-in @*sessions* ["cccccccccccccccc" ::pass/state])))
+     (is (= "bbbbbbbbbbbb" (get-in @*sessions* ["cccccccccccccccc" ::pass/nonce])))
+     (is (nil? (get-in @*sessions* ["cccccccccccccccc" ::pass/return-to])))
+
+     (is (= 303 (:ring.response/status resp)))
+     (is (= "https://excel.auth.us-east-2.amazoncognito.com/logout?response_type=code&scope=openid&client_id=clientid123456789abcdefghi&redirect_uri=https%3A%2F%2Fexample.org%2F_site%2Fopenid%2Faws-cognito%2Fcallback&state=aaaaaaaa&nonce=bbbbbbbbbbbb&prompt=login"
+            (get-in resp [:ring.response/headers "location"]))))))
+
+(deftest openid-login-with-return-to-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "clientid123456789abcdefghi"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (testing
+   (let [resp (with-redefs
+               [util/make-nonce tutils/mock-make-nonce]
+                (*handler*
+                 {:ring.request/method :get
+                  :ring.request/path "/_site/openid/aws-cognito/login"
+                  :ring.request/query "return-to=http://example.org/home.html"}))]
+
+     (is (contains? @*sessions* "cccccccccccccccc"))
+     (is (= "aaaaaaaa" (get-in @*sessions* ["cccccccccccccccc" ::pass/state])))
+     (is (= "bbbbbbbbbbbb" (get-in @*sessions* ["cccccccccccccccc" ::pass/nonce])))
+     (is (= "http://example.org/home.html" (get-in @*sessions* ["cccccccccccccccc" ::pass/return-to])))
+
+     (is (= 303 (:ring.response/status resp)))
+     (is (= "https://excel.auth.us-east-2.amazoncognito.com/logout?response_type=code&scope=openid&client_id=clientid123456789abcdefghi&redirect_uri=https%3A%2F%2Fexample.org%2F_site%2Fopenid%2Faws-cognito%2Fcallback&state=aaaaaaaa&nonce=bbbbbbbbbbbb&prompt=login"
+            (get-in resp [:ring.response/headers "location"])))
+     (is (= "id=cccccccccccccccc; Path=/; Secure; HttpOnly; SameSite=Lax"
+            (get-in resp [:ring.response/headers "set-cookie"]))))))
+
+(deftest openid-login-missing-client-id-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (testing
+   (let [resp (*handler*
+               {:ring.request/method :get
+                :ring.request/path "/_site/openid/aws-cognito/login"})]
+     (is (= "No oauth client id found" (get-in resp [::site/errors :message])))
+     (is (= 500 (:ring.response/status resp))))))
+
+(deftest openid-login-missing-configuration-test
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "clientid123456789abcdefghi"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (testing
+   (let [resp (*handler*
+               {:ring.request/method :get
+                :ring.request/path "/_site/openid/aws-cognito/login"})]
+     (is (= "No openid configuration found" (get-in resp [::site/errors :message])))
+     (is (= 500 (:ring.response/status resp))))))
+
+(deftest openid-aws-cognito-callback-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "3aaocetnk8d2941585k6nbbckc"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (test-util/submit-and-await!
+   [[:crux.tx/put
+     {:crux.db/id "https://example.org/_site/roles/superuser"
+      ::site/type "Role"
+      :name "superuser"
+      :description "Superuser"}]])
+
+  (auth/put-session!
+   "current-session"
+   {::pass/state "auth-flow-state"
+    ::pass/nonce "4f689a2585601d8050dc3cec"}
+   (.plusSeconds (Instant/now) 3600))
+
+  (testing
+   (let [resp (with-redefs
+               [hc/get (tutils/mock-openid-jwks-req "aws-cognito")
+                hc/post (tutils/mock-openid-token-req "aws-cognito")
+                auth/access-token (constantly "new-session")
+                openid/jwt-verifier
+                (fn [algorithm issuer]
+                  (.. (JWT/require algorithm)
+                      (withIssuer issuer)
+                      (acceptLeeway 1)
+                      (build (reify com.auth0.jwt.interfaces.Clock
+                               (getToday [_]
+                                 ; Token is valid from 2023-01-16T15:44:47.00Z and lasts an hour
+                                 ; so set time of validation to 2023-01-16T15:45:00.00Z
+                                 (java.util.Date/from
+                                  (java.time.Instant/parse "2023-01-16T15:45:00.00Z")))))))]
+
+                (*handler*
+                 {:ring.request/method :get
+                  :ring.request/path "/_site/openid/aws-cognito/callback"
+                  :ring.request/query "state=auth-flow-state&code=randomcode"
+                  :ring.request/headers {"cookie" "id=current-session"}}))
+         db (crux/db *crux-node*)]
+
+     (is (nil? (get @*sessions* "current-session")))
+     (is (contains? @*sessions* "new-session"))
+
+     (is (= 303 (:ring.response/status resp)))
+     (is (= "/?code=new-session"
+            (get-in resp [:ring.response/headers "location"])))
+
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin")
+            {:crux.db/id "https://example.org/_site/users/exceladmin"
+             ::site/type "User"
+             ::pass/username "exceladmin"
+             :name "Excel Admin"
+             :email "fwc+exceladmin@juxt.pro"}))
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin/oauth-credentials")
+            {:crux.db/id "https://example.org/_site/users/exceladmin/oauth-credentials"
+             ::site/type "OAuthCredentials"
+             ::pass/user "https://example.org/_site/users/exceladmin"
+             :juxt.pass.jwt/iss "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :juxt.pass.jwt/sub "2353661c-e432-464f-9b22-e908ddd920e5"}))
+     (is (some? (crux/entity db "https://example.org/_site/roles/superuser")))
+     (is (= (crux/entity db "https://example.org/_site/roles/superuser/users/exceladmin")
+            {:crux.db/id "https://example.org/_site/roles/superuser/users/exceladmin",
+             ::site/type "UserRoleMapping",
+             ::pass/assignee "https://example.org/_site/users/exceladmin",
+             ::pass/role "https://example.org/_site/roles/superuser"})))))
+
+(deftest openid-aws-cognito-callback-no-role-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "3aaocetnk8d2941585k6nbbckc"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (auth/put-session!
+   "current-session"
+   {::pass/state "auth-flow-state"
+    ::pass/nonce "4f689a2585601d8050dc3cec"}
+   (.plusSeconds (Instant/now) 3600))
+
+  (testing
+   (let [resp (with-redefs
+               [hc/get (tutils/mock-openid-jwks-req "aws-cognito")
+                hc/post (tutils/mock-openid-token-req "aws-cognito")
+                auth/access-token (constantly "new-session")
+                openid/jwt-verifier
+                (fn [algorithm issuer]
+                  (.. (JWT/require algorithm)
+                      (withIssuer issuer)
+                      (acceptLeeway 1)
+                      (build (reify com.auth0.jwt.interfaces.Clock
+                               (getToday [_]
+                                 ; Token is valid from 2023-01-16T15:44:47.00Z and lasts an hour
+                                 ; so set time of validation to 2023-01-16T15:45:00.00Z
+                                 (java.util.Date/from
+                                  (java.time.Instant/parse "2023-01-16T15:45:00.00Z")))))))]
+
+                (*handler*
+                 {:ring.request/method :get
+                  :ring.request/path "/_site/openid/aws-cognito/callback"
+                  :ring.request/query "state=auth-flow-state&code=randomcode"
+                  :ring.request/headers {"cookie" "id=current-session"}}))
+         db (crux/db *crux-node*)]
+
+     (is (nil? (get @*sessions* "current-session")))
+     (is (contains? @*sessions* "new-session"))
+
+     (is (= 303 (:ring.response/status resp)))
+     (is (= "/?code=new-session"
+            (get-in resp [:ring.response/headers "location"])))
+
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin")
+            {:crux.db/id "https://example.org/_site/users/exceladmin"
+             ::site/type "User"
+             ::pass/username "exceladmin"
+             :name "Excel Admin"
+             :email "fwc+exceladmin@juxt.pro"}))
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin/oauth-credentials")
+            {:crux.db/id "https://example.org/_site/users/exceladmin/oauth-credentials"
+             ::site/type "OAuthCredentials"
+             ::pass/user "https://example.org/_site/users/exceladmin"
+             :juxt.pass.jwt/iss "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :juxt.pass.jwt/sub "2353661c-e432-464f-9b22-e908ddd920e5"}))
+     (is (nil? (crux/entity db "https://example.org/_site/roles/superuser")))
+     (is (nil? (crux/entity db "https://example.org/_site/roles/superuser/user/exceladmin"))))))
+
+(deftest openid-aws-cognito-full-flow-test
+  (with-redefs
+   [slurp (tutils/mock-openid-configuration-req "aws-cognito")]
+    (site-init/install-openid-provider! *crux-node* "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"))
+
+  (site-init/install-openid-resources!
+   *crux-node*
+   {::site/base-uri "https://example.org"
+    :openid {:name "aws-cognito"
+             :issuer-id "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :client-id "3aaocetnk8d2941585k6nbbckc"
+             :client-secret "clientsecret123456789abcdefghi"}})
+
+  (test-util/submit-and-await!
+   [[:crux.tx/put
+     {:crux.db/id "https://example.org/_site/roles/superuser"
+      ::site/type "Role"
+      :name "superuser"
+      :description "Superuser"}]])
+
+  (testing
+   (let [login-resp
+         (with-redefs
+          [util/make-nonce (fn [len]
+                             (case len
+                               8 "aaaaaaaa"
+                               12 "4f689a2585601d8050dc3cec"
+                               16 "cccccccccccccccc"
+                               :else "x"))]
+           (*handler*
+            {:ring.request/method :get
+             :ring.request/path "/_site/openid/aws-cognito/login"}))
+         callback-resp
+         (with-redefs
+          [hc/get (tutils/mock-openid-jwks-req "aws-cognito")
+           hc/post (tutils/mock-openid-token-req "aws-cognito")
+           auth/access-token (constantly "dddddddddddddddd")
+           openid/jwt-verifier
+           (fn [algorithm issuer]
+             (.. (JWT/require algorithm)
+                 (withIssuer issuer)
+                 (acceptLeeway 1)
+                 (build (reify com.auth0.jwt.interfaces.Clock
+                          (getToday [_]
+                            ; Token is valid from 2023-01-16T15:44:47.00Z and lasts an hour
+                            ; so set time of validation to 2023-01-16T15:45:00.00Z
+                            (java.util.Date/from
+                             (java.time.Instant/parse "2023-01-16T15:45:00.00Z")))))))]
+
+           (*handler*
+            {:ring.request/method :get
+             :ring.request/path "/_site/openid/aws-cognito/callback"
+             :ring.request/query "state=aaaaaaaa&code=randomcode"
+             :ring.request/headers {"cookie" (get-in login-resp [:ring.response/headers "set-cookie"])}}))
+         db (crux/db *crux-node*)]
+
+     (is (nil? (get @*sessions* "cccccccccccccccc")))
+     (is (contains? @*sessions* "dddddddddddddddd"))
+
+     (is (= 303 (:ring.response/status callback-resp)))
+     (is (= "/?code=dddddddddddddddd"
+            (get-in callback-resp [:ring.response/headers "location"])))
+
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin")
+            {:crux.db/id "https://example.org/_site/users/exceladmin"
+             ::site/type "User"
+             ::pass/username "exceladmin"
+             :name "Excel Admin"
+             :email "fwc+exceladmin@juxt.pro"}))
+     (is (= (crux/entity db "https://example.org/_site/users/exceladmin/oauth-credentials")
+            {:crux.db/id "https://example.org/_site/users/exceladmin/oauth-credentials"
+             ::site/type "OAuthCredentials"
+             ::pass/user "https://example.org/_site/users/exceladmin"
+             :juxt.pass.jwt/iss "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6"
+             :juxt.pass.jwt/sub "2353661c-e432-464f-9b22-e908ddd920e5"}))
+     (is (some? (crux/entity db "https://example.org/_site/roles/superuser")))
+     (is (= (crux/entity db "https://example.org/_site/roles/superuser/users/exceladmin")
+            {:crux.db/id "https://example.org/_site/roles/superuser/users/exceladmin",
+             ::site/type "UserRoleMapping",
+             ::pass/assignee "https://example.org/_site/users/exceladmin",
+             ::pass/role "https://example.org/_site/roles/superuser"})))))

--- a/test/juxt/pass/openid_connect_test_utils.clj
+++ b/test/juxt/pass/openid_connect_test_utils.clj
@@ -1,0 +1,103 @@
+(ns juxt.pass.openid-connect-test-utils
+  (:require
+   [clojure.test :refer [is]]
+   [jsonista.core :as json]))
+
+(def mock-openid-configuration
+  {"auth0"
+   {:url
+    "https://dev-14bkigf7.us.auth0.com/.well-known/openid-configuration"
+    :doc
+    "{\"issuer\":\"https://dev-14bkigf7.us.auth0.com/\",
+      \"authorization_endpoint\":\"https://dev-14bkigf7.us.auth0.com/authorize\",
+      \"token_endpoint\":\"https://dev-14bkigf7.us.auth0.com/oauth/token\",
+      \"device_authorization_endpoint\":\"https://dev-14bkigf7.us.auth0.com/oauth/device/code\",
+      \"userinfo_endpoint\":\"https://dev-14bkigf7.us.auth0.com/userinfo\",
+      \"mfa_challenge_endpoint\":\"https://dev-14bkigf7.us.auth0.com/mfa/challenge\",
+      \"jwks_uri\":\"https://dev-14bkigf7.us.auth0.com/.well-known/jwks.json\",
+      \"registration_endpoint\":\"https://dev-14bkigf7.us.auth0.com/oidc/register\",
+      \"revocation_endpoint\":\"https://dev-14bkigf7.us.auth0.com/oauth/revoke\",
+      \"scopes_supported\":[\"openid\",\"profile\",\"offline_access\",\"name\",\"given_name\",\"family_name\",\"nickname\",\"email\",\"email_verified\",\"picture\",\"created_at\",\"identities\",\"phone\",\"address\"],
+      \"response_types_supported\":[\"code\",\"token\",\"id_token\",\"code token\",\"code id_token\",\"token id_token\",\"code token id_token\"],
+      \"code_challenge_methods_supported\":[\"S256\",\"plain\"],
+      \"response_modes_supported\":[\"query\",\"fragment\",\"form_post\"],
+      \"subject_types_supported\":[\"public\"],
+      \"id_token_signing_alg_values_supported\":[\"HS256\",\"RS256\"],
+      \"token_endpoint_auth_methods_supported\":[\"client_secret_basic\",\"client_secret_post\"],
+      \"claims_supported\":[\"aud\",\"auth_time\",\"created_at\",\"email\",\"email_verified\",\"exp\",\"family_name\",\"given_name\",\"iat\",\"identities\",\"iss\",\"name\",\"nickname\",\"phone_number\",\"picture\",\"sub\"],
+      \"request_uri_parameter_supported\":false,
+      \"request_parameter_supported\":false}"}
+
+   "aws-cognito"
+   {:url
+    "https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6/.well-known/openid-configuration"
+    :doc
+    "{\"authorization_endpoint\":\"https://excel.auth.us-east-2.amazoncognito.com/oauth2/authorize\",
+      \"id_token_signing_alg_values_supported\":[\"RS256\"],
+      \"issuer\":\"https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6\",
+      \"jwks_uri\":\"https://cognito-idp.us-east-2.amazonaws.com/us-east-2_ccXNbbzY6/.well-known/jwks.json\",
+      \"response_types_supported\":[\"code\",\"token\"],
+      \"scopes_supported\":[\"openid\",\"email\",\"phone\",\"profile\"],
+      \"subject_types_supported\":[\"public\"],
+      \"token_endpoint\":\"https://excel.auth.us-east-2.amazoncognito.com/oauth2/token\",
+      \"token_endpoint_auth_methods_supported\":[\"client_secret_basic\",\"client_secret_post\"],
+      \"userinfo_endpoint\":\"https://excel.auth.us-east-2.amazoncognito.com/oauth2/userInfo\"}"}})
+
+(defn mock-openid-configuration-req
+  [provider]
+  (let [{:keys [url doc]} (get mock-openid-configuration provider)]
+    (fn [conf-url]
+      (is (= url conf-url))
+      doc)))
+
+(defn mock-make-nonce
+  [len]
+  (case len
+    8 "aaaaaaaa"
+    12 "bbbbbbbbbbbb"
+    16 "cccccccccccccccc"
+    :else "x"))
+
+(def mock-openid-jwks
+  {"aws-cognito"
+   "{\"keys\":[{\"alg\":\"RS256\",
+                \"e\":\"AQAB\",
+                \"kid\":\"HfPNX7FSg4eQfhZXeWT9vZYjzr148oIaAYS72e50xys=\",
+                \"kty\":\"RSA\",
+                \"n\":\"00mEv_bfufZMBPWrSjzX5x8xHiqR963pYeGud0aTXpv5ujYjWGYFchhibvQWEu0Llv3J87NPe2v3nCBWgOzZeSDBYTVbttNS96ZZZnG-N5pGC-3rGR6jbqQGcqDWX36i1c_ynqKdCkknARipbA95dsbUHsKB6YZGxqBe3gnA9twWPNMppEOKtD4ZUi78moF8JB0PNLZM_kVa0AD6fvHB26PkFu9k_YdQ4EoC-HRPJKVVO_IRvxGKvnR9PMLQ7z-Jz4Bqcbo67wR0QuouISC1iFjY07FC7mfKGywhuU8oLFDaw5ZOxuSFF8jSjA35EM7nS5ukcChTCSwzRjlUpJ0ndw\",
+                \"use\":\"sig\"},
+               {\"alg\":\"RS256\",
+                \"e\":\"AQAB\",
+                \"kid\":\"31uL7Hv7H6CMEDwLnS+qwVVsLqIghtqplWVGxIMqsmQ=\",
+                \"kty\":\"RSA\",
+                \"n\":\"1wXQyFM5VBnnTNmsKuIowz-XXOBGNrZXzQGrar_1tyNtsDXhBV1semfN6aKTPJn1BZ-5P3brKcYYDOaAB0TyeZ4fdBGUc8Rj07T43VyBWtFtC_xFqm5nI1UfrYjXvc7f4JN3ZNqatYuQT1C_MUn1uqlHV4_5b-ECK6ct1FYgDBANgjFLuysmoml6vXTPUpXsKENz56YgMNuhixXYT-G-0olTIwPlDyWPfXTAeazRs-YqRQk_xiALiNDjyFywivtKXqZ1mldxQarWl81sm3_kxHtc1d5pNFIGW2D-RBxDUmNUEM-JGNWP636XzQWL97E_shHryQJzxUyCn0EuM3PBFw\",
+                \"use\":\"sig\"}]}\n"})
+
+(defn mock-openid-jwks-req
+  [provider]
+  (let [{:keys [doc]} (get mock-openid-configuration provider)
+        url (get (json/read-value doc) "jwks_uri")]
+    (fn [jwks-endpoint {:keys [accept]}]
+      (is (= url jwks-endpoint))
+      (is (= :json accept))
+      {:status 200
+       :body (get mock-openid-jwks provider)})))
+
+(def mock-openid-token
+  {"aws-cognito"
+   "{\"id_token\":\"eyJraWQiOiJIZlBOWDdGU2c0ZVFmaFpYZVdUOXZaWWp6cjE0OG9JYUFZUzcyZTUweHlzPSIsImFsZyI6IlJTMjU2In0.eyJhdF9oYXNoIjoia2FMbWhFeG85T3cxZlJRaXdMOV9lZyIsInN1YiI6IjIzNTM2NjFjLWU0MzItNDY0Zi05YjIyLWU5MDhkZGQ5MjBlNSIsImNvZ25pdG86Z3JvdXBzIjpbInN1cGVydXNlciJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6XC9cL2NvZ25pdG8taWRwLnVzLWVhc3QtMi5hbWF6b25hd3MuY29tXC91cy1lYXN0LTJfY2NYTmJielk2IiwiY29nbml0bzp1c2VybmFtZSI6ImV4Y2VsYWRtaW4iLCJub25jZSI6IjRmNjg5YTI1ODU2MDFkODA1MGRjM2NlYyIsIm9yaWdpbl9qdGkiOiJkNTlkZTY5YS03MDgxLTQ5MTgtYmY4NC04MjE4YjU1ZGZjNDciLCJhdWQiOiIzYWFvY2V0bms4ZDI5NDE1ODVrNm5iYmNrYyIsImV2ZW50X2lkIjoiNGRkYTQ2ZjQtNGU5Yi00ZWE5LTk1MzktMDY2OTFlMjNlOTJiIiwidG9rZW5fdXNlIjoiaWQiLCJhdXRoX3RpbWUiOjE2NzM4ODM4ODcsIm5hbWUiOiJFeGNlbCBBZG1pbiIsImV4cCI6MTY3Mzg4NzQ4NywiaWF0IjoxNjczODgzODg3LCJqdGkiOiJiODQ2YTYwZi01ZWM1LTQ4ZDgtYTQyZC0yNDAzMzIxNWMzNGMiLCJlbWFpbCI6ImZ3YytleGNlbGFkbWluQGp1eHQucHJvIn0.qCa3GvhAcbxy4f8sgjPQX-6OHPlmaV03shsdNuCQP6hp0u3MsuoVZIhHVv0kIBikB-94NJsFGAqqKASZ9P6Z8OClHzcQsRC2pad0WAUL1tne_-4o309AvCAdeGOTcgzcwdVk1wPFH9rBYYEF-0ou0wzpPOHx8CTRhTqHYcKAHxVz_rleDkp8LRuRUkG0vz4DcOeaF7Fj6nCDuFmYQag2ZgEHjM6iPJdovyZDYwIUjUCwl6jHNL1meNWlQEvMi0_xVlozSs4y6P58Drafhwk2P8wL9ZpTG0Et3QhhHXvdQs1xBVNQlSbmxBIIZ9jPiejkOh60kQeB8SVRSsT5HgXzLA\",
+     \"access_token\":\"omitted-content\",
+     \"refresh_token\":\"omitted-content\",
+     \"expires_in\":3600,
+     \"token_type\":\"Bearer\"}"})
+
+(defn mock-openid-token-req
+  [provider]
+  (let [{:keys [doc]} (get mock-openid-configuration provider)
+        url (get (json/read-value doc) "token_endpoint")]
+    (fn [token-endpoint {:keys [form-params accept]}]
+      (is (= url token-endpoint))
+      (is (= "authorization_code" (get form-params "grant_type")))
+      (is (= :json accept))
+      {:status 200
+       :body (get mock-openid-token provider)})))


### PR DESCRIPTION
This changes are necessary to close issue [#328](https://github.com/juxt/excel/issues/328) of [juxt/excel](https://github.com/juxt/excel/).
The most significant changes are:
- Change `/_site/user` endpoint to return data when user has no `UserRoleMapping` entities associated with them (outer join)
- Change OAuth flow to create/update `User` entities on successful auth and update associated `UserRoleMapping`
- Add Tests for the OAuth flow code, specifically the login and callback endpoints