### PR TITLE
Ensure merge-with-flatten returns distinct values

### DIFF
--- a/src/juxt/mail/alpha/mail.clj
+++ b/src/juxt/mail/alpha/mail.clj
@@ -112,4 +112,4 @@
   (fn
     ([] nil)
     ([acc] acc)
-    ([acc x] (merge-with #(flatten [%1 %2]) acc x))))
+    ([acc x] (merge-with #(-> [%1 %2] flatten distinct) acc x))))


### PR DESCRIPTION
Without this change merge-with-flatten can results in list within a map that contains multiple of the same value. This is undesirable as it is being used to return a list of email addresses to receive a message.