### PR TITLE
Fix mail templating of non-strings

### DIFF
--- a/src/juxt/mail/alpha/mail.clj
+++ b/src/juxt/mail/alpha/mail.clj
@@ -66,13 +66,14 @@
   (str/replace
    template #"\{\{([^\}]*)\}\}"
    (fn [[_ grp]]
-     (get-in
-      data
-      (for [mtch (re-seq #"[\p{Alnum}\.:/_-]+" grp)]
-        (cond (.startsWith mtch ":") (keyword (subs mtch 1))
-              ;(re-matches #"\"([\"]*)\"" (string))
-              :else  mtch))
-      "<blank>"))))
+     (-> (get-in
+          data
+          (for [mtch (re-seq #"[\p{Alnum}\.:/_-]+" grp)]
+            (cond (.startsWith mtch ":") (keyword (subs mtch 1))
+                  ;(re-matches #"\"([\"]*)\"" (string))
+                  :else  mtch))
+          "<blank>")
+         str))))
 
 (defmethod triggers/run-action! ::mail/send-emails
   [{::site/keys [db ses-client]} {:keys [trigger action-data]}]
@@ -102,10 +103,10 @@
          (mail-merge subject data)
          (mail-merge text-template data))))))
 
-(defmethod cruxq/aggregate 'distinct-string-list [_]
+(defmethod cruxq/aggregate 'sorted-string-list [_]
   (fn
     ([] #{})
-    ([acc] (str/join "&" acc))
+    ([acc] (str/join "&" (sort acc)))
     ([acc x] (conj acc x))))
 
 (defmethod cruxq/aggregate 'merge-with-flatten [_]


### PR DESCRIPTION
clojure.string/replace expects the result of the replacement function to return a string, or a value that can be cast to a string. To prevent class cast exceptions where the object cannot be cast to a string str is called to call .toString() on all returned objects. Specifically, this allows numeric values to be templated. This is needed to allow the result of the `max` aggregate function to be templated correctly, as it returns a long.

Also, change crux aggregate function distinct-string-list to sorted-string-list. Function must sort the values into a logical order.