### PR TITLE
Store sessions in db and extend token sessions

### DIFF
--- a/src/juxt/pass/alpha/openid_connect.clj
+++ b/src/juxt/pass/alpha/openid_connect.clj
@@ -64,12 +64,13 @@
 
         ;; Create a pre-auth session
         session-token-id! (make-nonce 16)
-        expires-in (get resource ::pass/expires-in (* 24 3600))
         _ (put-session!
+           req
            session-token-id!
-           (cond-> {::pass/state state ::pass/nonce nonce}
-             return-to (assoc ::pass/return-to return-to))
-           (.plusSeconds (.toInstant start-date) expires-in))
+           (cond-> {::pass/state state
+                    ::pass/nonce nonce
+                    :expires_in (* 24 3600)}
+             return-to (assoc ::pass/return-to return-to)))
 
         query-string
         (codec/form-encode

--- a/src/juxt/site/alpha/init.clj
+++ b/src/juxt/site/alpha/init.clj
@@ -155,7 +155,7 @@
       {"http://localhost:8000"
        {::site/access-control-allow-methods #{:post}
         ::site/access-control-allow-headers #{"authorization" "content-type"}}}
-      ::pass/expires-in (* 60 60 1)}
+      ::pass/expires-in (* 3600 24 7)}
 
      {:crux.db/id (str base-uri "/_site/rules/anyone-can-ask-for-a-token")
       ::site/type "Rule"
@@ -194,7 +194,7 @@
     ::http/methods #{:post}
     ::http/acceptable "application/x-www-form-urlencoded"
     ::site/purpose ::site/login
-    ::pass/expires-in (* 3600 24 30)}
+    ::pass/expires-in (* 3600 24 7)}
 
    {:crux.db/id (str base-uri "/_site/rules/anyone-can-post-login-credentials")
     ::site/type "Rule"

--- a/src/juxt/site/alpha/repl.clj
+++ b/src/juxt/site/alpha/repl.clj
@@ -168,13 +168,6 @@
        (println "Evicting" (count batch) "records")
        (println (apply evict! batch))))))
 
-(defn sessions []
-  (authn/expire-sessions! (java.util.Date.))
-  (deref authn/sessions-by-access-token))
-
-(defn clear-sessions []
-  (reset! authn/sessions-by-access-token {}))
-
 (defn superusers
   ([] (superusers (config)))
   ([{::site/keys [base-uri]}]


### PR DESCRIPTION
Store user sessions in Crux rather than in an atom to allow for multiple instances of site to access the same sessions and to persist sessions between restarts. These changes also update the openid connect tests to assert that the expected sessions are created in the database.

The expiry time of sessions created by calling the token endpoint has been extended from 1 hour to 1 week. Sessions created by logging in by basic auth have been reduced to 1 week from 1 month to be consistent. This change has been made to resolve the issue of users being automatically logged out after long periods of inactivity.