### PR TITLE
Allium spec distillation — run 772cc568

### DIFF
--- a/specs/site.allium
+++ b/specs/site.allium
@@ -1,0 +1,164 @@
+-- allium: 3
+-- site.allium
+-- Distilled from juxt/site (Site 1.0): a Resource Server built on XTDB
+-- that stores web resources and serves OpenAPI-defined APIs with
+-- Policy-Based Access Control (Pass).
+
+------------------------------------------------------------
+-- External Entities
+------------------------------------------------------------
+
+external entity HttpClient {
+    user_agent: String
+}
+
+external entity XtdbDatabase {
+    name: String
+}
+
+external entity OpenAPIDefinition {
+    content_hash: String
+}
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum HttpMethod {
+    get | put | post | delete | head | options | patch
+}
+
+enum AuthzDecision {
+    permit | deny | not_applicable
+}
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value HttpRequest {
+    method: HttpMethod
+    uri: String
+    content_type: String?
+}
+
+value HttpResponse {
+    status: Integer
+    content_type: String?
+}
+
+value Representation {
+    uri: String
+    content_type: String
+    body_hash: String
+    etag: String?
+}
+
+------------------------------------------------------------
+-- Actors
+------------------------------------------------------------
+
+actor Subject {
+    subject_uri: String
+}
+
+------------------------------------------------------------
+-- Entities
+------------------------------------------------------------
+
+entity Resource {
+    uri: String
+    current: Representation?
+    exists: Boolean
+}
+
+entity ApiDefinition {
+    base_uri: String
+    definition: OpenAPIDefinition
+    served: Boolean
+}
+
+entity AuthzPolicy {
+    policy_uri: String
+    active: Boolean
+}
+
+------------------------------------------------------------
+-- Surfaces
+------------------------------------------------------------
+
+surface HttpApi {
+    put_resource: (request: HttpRequest) -> HttpResponse
+    get_resource: (request: HttpRequest) -> HttpResponse
+    delete_resource: (request: HttpRequest) -> HttpResponse
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+rule PutCreatesOrReplacesRepresentation {
+    when: SubjectSendsRequest(subject, request)
+    requires: request.method = put
+    ensures:
+        Resource.upserted(uri: request.uri, exists: true)
+}
+
+rule GetReturnsCurrentRepresentation {
+    when: SubjectSendsRequest(subject, request)
+    requires: request.method = get
+    ensures:
+        HttpResponse.returned(status: 200, content_type: request.content_type)
+}
+
+rule DeleteRemovesResource {
+    when: SubjectSendsRequest(subject, request)
+    requires: request.method = delete
+    ensures:
+        Resource.updated(uri: request.uri, exists: false)
+}
+
+rule OpenApiDocumentsBecomeApis {
+    when: SubjectSendsRequest(subject, request)
+    requires: request.method = put
+    ensures:
+        ApiDefinition.registered(base_uri: request.uri, served: true)
+}
+
+rule RequestsAreAuthorized {
+    when: SubjectSendsRequest(subject, request)
+    ensures:
+        AuthzDecision.computed(subject: subject, request: request)
+}
+
+rule HistoryIsImmutable {
+    when: ResourceRepresentationChanged(uri)
+    ensures:
+        XtdbDatabase.preserves_prior_versions(uri: uri)
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant DenyByDefault {
+    -- Any request whose AuthzDecision is deny or not_applicable
+    -- must not mutate or reveal a Resource.
+}
+
+invariant ContentAddressableHistory {
+    -- Every Representation ever stored remains retrievable by
+    -- (uri, system_time) from the underlying XtdbDatabase.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "Exact set of authentication mechanisms (basic, bearer, OpenID Connect) supported and their precedence."
+
+open question "Schema and lifecycle of Pass policy documents - how they are loaded, versioned, and revoked."
+
+open question "Content negotiation, conditional and range request semantics are implemented but not modelled here."
+
+open question "Admin and bootstrap surface for installing the initial subject, policy, and OpenAPI documents."


### PR DESCRIPTION
## Allium spec — first pass

This PR carries the first pass of an Allium specification distilled from the
codebase by allium-swarm.

**Run ID:** `772cc568-d76f-466f-a382-39591031be7c`
**Spec ID:** `3637c850-a5e8-4386-ba03-b0ccf0126daa`
**Files:**

- `specs/...`

Distilled a first-pass Allium v3 spec for juxt/site (Site 1.0): an XTDB-backed HTTP Resource Server that stores representations addressable by URI, recognises OpenAPI 3 documents on PUT and serves them as APIs, and authorizes every request against Pass policies. The spec captures the HTTP surface (PUT/GET/DELETE), the Resource/ApiDefinition/AuthzPolicy entities, an HttpMethod and AuthzDecision enum, lifecycle rules for resource mutation and authorization, and invariants for deny-by-default and bitemporal history preservation. Validates clean under `allium check` (only unused-entity warnings).

---

This is a *ratification gate*. Two equivalent ways to ratify:

1. **PR review with state Approved.** Open *Files changed* → *Review changes* → Approve. (GitHub forbids the PR's author from approving their own PR — if you opened it, use option 2.)
2. **/ratify comment.** Post a comment on this PR whose body starts with `/ratify`. Anything after the token is captured as the ratification rationale.

Merge is optional — approval alone is the signal.

If anything is missing, request changes (or post a comment) and the
orchestrator will re-distil with your feedback as additional context (up to
3 rounds).

<!-- allium-swarm:run_id=772cc568-d76f-466f-a382-39591031be7c -->
<!-- allium-swarm:spec_id=3637c850-a5e8-4386-ba03-b0ccf0126daa -->
