### PR TITLE
ci: bootstrap GitHub Actions smoke job (allium-swarm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@13.0
+        with:
+          cli: latest
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-${{ hashFiles('**/deps.edn') }}
+      - name: Resolve deps
+        run: clojure -P
+      - name: Try project test runner (best-effort, won't fail the job)
+        run: |
+          if [ -f Makefile ] && grep -qE '^test:' Makefile; then
+            make test || echo "::warning::make test failed; smoke (deps-resolve) still passed"
+          elif clojure -A:test -e 'nil' 2>/dev/null; then
+            clojure -X:test || clojure -M:test || echo "::warning::test alias present but command failed"
+          else
+            echo "no :test alias / no Makefile test target — smoke job covers deps-resolve only"
+          fi


### PR DESCRIPTION
## Summary

Generated by **allium-swarm** stage `01a` (`--ci-bootstrap`).

The repo currently has only `.circleci/config.yml` and zero GitHub Actions workflows. This PR adds a minimal `.github/workflows/ci.yml` so the allium-swarm pipeline (and reviewers) can observe whether changes still build cleanly. The job:

1. Resolves Clojure deps (`clojure -P`) — universal smoke.
2. Best-effort: runs the project's test runner if a `Makefile` `test` target or `:test` alias is present, never failing the job (warnings only).

This is a starter — refine the test step to match the project's preferred runner (kaocha via `make test`?) once the loop is proven.

## Test plan

- [ ] GitHub Actions run on this PR completes (green or red — we want to see the loop)
- [ ] Re-run `allium-swarm` stage 01a after the run; confirm `ci_baseline.json` now records the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)